### PR TITLE
chat stuff

### DIFF
--- a/src/main/java/cc/hyperium/cosmetics/ChromaWinCosmetic.java
+++ b/src/main/java/cc/hyperium/cosmetics/ChromaWinCosmetic.java
@@ -176,9 +176,6 @@ import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.util.EnumChatFormatting;
 
 import java.awt.*;
-import java.util.regex.Matcher;
-
-import static cc.hyperium.handlers.handlers.chat.HyperiumChatHandler.winPattern;
 
 /*
  * Created by Cubxity on 21/03/2018
@@ -210,16 +207,21 @@ public class ChromaWinCosmetic extends AbstractCosmetic {
             h = 0;
     }
 
+    // Should actually change the regex instead of doing this cub
     @InvokeEvent
-    public void onChat(ChatEvent e){
-        if(winPattern == null)return;
+    public void onChat(ChatEvent e) {
         String text = EnumChatFormatting.getTextWithoutFormattingCodes(e.getChat().getUnformattedText());
-        Matcher matcher = winPattern.matcher(text);
-        if (matcher.matches())
-            if (matcher.group("winners").contains(Minecraft.getMinecraft().thePlayer.getName()))
-                chroma(60);
-            else if(text.toLowerCase().contains(Minecraft.getMinecraft().thePlayer.getName().toLowerCase()+" winner!"))
-                chroma(60);
+
+        if(text.toLowerCase().contains(Minecraft.getMinecraft().thePlayer.getName().toLowerCase()+" winner!")) {
+            chroma(60);
+        }
+    }
+
+    @InvokeEvent
+    public void onWin(HypixelWinEvent event) {
+        if (event.getWinners().contains(Minecraft.getMinecraft().thePlayer.getName())) {
+            chroma(60);
+        }
     }
 
     public void chroma(int ticks){

--- a/src/main/java/cc/hyperium/cosmetics/ChromaWinCosmetic.java
+++ b/src/main/java/cc/hyperium/cosmetics/ChromaWinCosmetic.java
@@ -173,7 +173,6 @@ import cc.hyperium.purchases.EnumPurchaseType;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.ScaledResolution;
-import net.minecraft.util.EnumChatFormatting;
 
 import java.awt.*;
 
@@ -205,16 +204,6 @@ public class ChromaWinCosmetic extends AbstractCosmetic {
         h += 0.05;
         if(h >= 1)
             h = 0;
-    }
-
-    // Should actually change the regex instead of doing this cub
-    @InvokeEvent
-    public void onChat(ChatEvent e) {
-        String text = EnumChatFormatting.getTextWithoutFormattingCodes(e.getChat().getUnformattedText());
-
-        if(text.toLowerCase().contains(Minecraft.getMinecraft().thePlayer.getName().toLowerCase()+" winner!")) {
-            chroma(60);
-        }
     }
 
     @InvokeEvent

--- a/src/main/java/cc/hyperium/handlers/HyperiumHandlers.java
+++ b/src/main/java/cc/hyperium/handlers/HyperiumHandlers.java
@@ -93,6 +93,8 @@ public class HyperiumHandlers {
         registerChatHandler(new PrivateMessageReader());
         registerChatHandler(new GuildPartyChatParser());
         registerChatHandler(questTracking = new QuestTrackingChatHandler());
+        registerChatHandler(new FriendRequestChatHandler());
+        registerChatHandler(new PartyInviteChatHandler());
         System.out.println("Registering events");
         EventBus.INSTANCE.register(this);
         System.out.println("Done");

--- a/src/main/java/cc/hyperium/handlers/handlers/chat/FriendRequestChatHandler.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/chat/FriendRequestChatHandler.java
@@ -1,0 +1,23 @@
+package cc.hyperium.handlers.handlers.chat;
+
+import cc.hyperium.event.EventBus;
+import cc.hyperium.event.HypixelFriendRequestEvent;
+import net.minecraft.util.IChatComponent;
+
+import java.util.regex.Matcher;
+
+public class FriendRequestChatHandler extends HyperiumChatHandler {
+
+    @Override
+    public boolean chatReceived(IChatComponent component, String text) {
+        if (!text.toLowerCase().contains("friend request")) {
+            return false;
+        }
+
+        Matcher matcher = regexPatterns.get(ChatRegexType.FRIEND_REQUEST).matcher(text);
+        if (matcher.find()) {
+            EventBus.INSTANCE.post(new HypixelFriendRequestEvent(matcher.group("player")));
+        }
+        return false;
+    }
+}

--- a/src/main/java/cc/hyperium/handlers/handlers/chat/GeneralChatHandler.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/chat/GeneralChatHandler.java
@@ -17,8 +17,15 @@
 
 package cc.hyperium.handlers.handlers.chat;
 
+import java.util.EnumMap;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.regex.Pattern;
+
 import cc.hyperium.Hyperium;
-import cc.hyperium.event.*;
+import cc.hyperium.event.ChatEvent;
+import cc.hyperium.event.InvokeEvent;
+import cc.hyperium.event.TickEvent;
 import cc.hyperium.handlers.handlers.remoteresources.RemoteResourcesHandler;
 import cc.hyperium.utils.ChatColor;
 import cc.hyperium.utils.JsonHolder;
@@ -27,20 +34,12 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
 
-import java.util.List;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 /**
  * @author Sk1er
  */
 public class GeneralChatHandler {
 
     private static GeneralChatHandler generalChatHandler = null;
-    // The chat pattern for friend requests
-    private Pattern patternFriendRequest = Pattern.compile("Friend request from ((?<rank>\\[.+] )?(?<player>\\w+)).*");
-    private Pattern patternPartyInvite = Pattern.compile("(\\[.*] )?(?<player>\\w+) has invited you to join (?<party>\\w+) party!");
     private List<HyperiumChatHandler> handlerList;
 
     private ConcurrentLinkedQueue<IChatComponent> messages = new ConcurrentLinkedQueue<>();
@@ -88,6 +87,7 @@ public class GeneralChatHandler {
         boolean state = true;
         if(!posted)
             return;
+
         for (HyperiumChatHandler chatHandler : handlerList) {
             //Surround in try catch so errors don't stop further chat parsers
             try {
@@ -96,7 +96,10 @@ public class GeneralChatHandler {
                     return;
                 }
 
-                state = state && chatHandler.chatReceived(event.getChat(), strip(event.getChat()));
+				// Is reversed because chathandlers weren't called if state was false, since
+				// false && boolean will always be false, so it skipped the
+				// HyperiumChatHandler#chatReceived method
+                state = chatHandler.chatReceived(event.getChat(), strip(event.getChat())) && state;
 
             } catch (Exception e) {
                 e.printStackTrace();
@@ -105,49 +108,20 @@ public class GeneralChatHandler {
         event.setCancelled(state);
     }
 
-    /**
-     * A better way to handle incoming friend requests
-     *
-     * @param event the ChatEvent
-     * @author boomboompower
-     */
-    @InvokeEvent
-    public void onFriendReceived(ChatEvent event) {
-        if (!event.getChat().getUnformattedText().toLowerCase().contains("friend request")) {
-            return;
-        }
-
-        Matcher matcher = this.patternFriendRequest.matcher(ChatColor.stripColor(event.getChat().getUnformattedText()));
-
-        if (matcher.find()) {
-            EventBus.INSTANCE.post(new HypixelFriendRequestEvent(matcher.group("player")));
-        }
-    }
-
-    @InvokeEvent
-    public void onPartyReceived(ChatEvent event) {
-        if (!event.getChat().getUnformattedText().toLowerCase().contains("their party!")) {
-            return;
-        }
-
-        Matcher matcher = this.patternPartyInvite.matcher(ChatColor.stripColor(event.getChat().getUnformattedText()));
-
-        if (matcher.find()) {
-            EventBus.INSTANCE.post(new HypixelPartyInviteEvent(matcher.group("player")));
-        }
-    }
-
     public void post() {
         Hyperium.INSTANCE.getHandlers().getRemoteResourcesHandler().getResourceAsync("chat_regex.json", RemoteResourcesHandler.ResourceType.TEXT, res -> {
             HyperiumChatHandler.regexs = res;
             JsonHolder data = res.getasJson();
-            HyperiumChatHandler.guildChatPattern = Pattern.compile(data.optString("guild_chat"));
-            HyperiumChatHandler.partyChatPattern = Pattern.compile(data.optString("party_chat"));
-            HyperiumChatHandler.skywarsRankedRating = Pattern.compile(data.optString("skywars_rating"));
-            HyperiumChatHandler.privateMessageTo = Pattern.compile(data.optString("private_message_to"));
-            HyperiumChatHandler.privateMessageFrom = Pattern.compile(data.optString("private_message_from"));
-            HyperiumChatHandler.completePattern = Pattern.compile(data.optString("quest_complete"));
 
+            HyperiumChatHandler.regexPatterns = new EnumMap<>(HyperiumChatHandler.ChatRegexType.class);
+            for (HyperiumChatHandler.ChatRegexType type : HyperiumChatHandler.ChatRegexType.values()) {
+                if (!data.has(type.name().toLowerCase())) {
+                    Hyperium.LOGGER.error("Could not find chat regex type " + type.name().toLowerCase() + " in the remote file.");
+                    continue;
+                }
+
+                HyperiumChatHandler.regexPatterns.put(type, Pattern.compile(data.optString(type.name().toLowerCase())));
+            }
 
             posted = true;
             for (HyperiumChatHandler chatHandler : handlerList) {

--- a/src/main/java/cc/hyperium/handlers/handlers/chat/GuildPartyChatParser.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/chat/GuildPartyChatParser.java
@@ -29,13 +29,13 @@ import java.util.regex.Matcher;
 public class GuildPartyChatParser extends HyperiumChatHandler {
     @Override
     public boolean chatReceived(IChatComponent component, String text) {
-        Matcher guildMatcher = guildChatPattern.matcher(text);
+        Matcher guildMatcher = regexPatterns.get(ChatRegexType.GUILD_CHAT).matcher(text);
         if (guildMatcher.matches()) {
             String player = guildMatcher.group("player");
             String message = guildMatcher.group("message");
             Hyperium.INSTANCE.getHandlers().getPrivateMessageHandler().getChat("guild").newMessage(message, player, Minecraft.getMinecraft().getSession().getUsername().equals(player));
         }
-        Matcher partyMatcher = partyChatPattern.matcher(text);
+        Matcher partyMatcher = regexPatterns.get(ChatRegexType.PARTY_CHAT).matcher(text);
         if (partyMatcher.matches()) {
             String player = partyMatcher.group("player");
             String message = partyMatcher.group("message");

--- a/src/main/java/cc/hyperium/handlers/handlers/chat/HyperiumChatHandler.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/chat/HyperiumChatHandler.java
@@ -17,12 +17,14 @@
 
 package cc.hyperium.handlers.handlers.chat;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.regex.Pattern;
+
 import cc.hyperium.Hyperium;
 import cc.hyperium.handlers.handlers.remoteresources.HyperiumResource;
 import cc.hyperium.utils.JsonHolder;
 import net.minecraft.util.IChatComponent;
-
-import java.util.regex.Pattern;
 
 /**
  * @author Sk1er
@@ -30,13 +32,7 @@ import java.util.regex.Pattern;
 public abstract class HyperiumChatHandler {
     //Resource *should* be loaded by then sooooo
     protected static HyperiumResource regexs;
-    protected static Pattern guildChatPattern = null;
-    protected static Pattern partyChatPattern = null;
-    protected static Pattern skywarsRankedRating = null;
-    protected static Pattern privateMessageTo = null;
-    protected static Pattern privateMessageFrom = null;
-    protected static Pattern completePattern = null;
-
+    protected static Map<ChatRegexType, Pattern> regexPatterns;
 
     public Hyperium getHyperium() {
         return Hyperium.INSTANCE;
@@ -52,4 +48,20 @@ public abstract class HyperiumChatHandler {
     public void callback(JsonHolder data) {
 
     }
+
+	public enum ChatRegexType {
+		SKYWARS_RATING, //
+		PRIVATE_MESSAGE_TO, //
+		PRIVATE_MESSAGE_FROM, //
+		FRIEND_REQUEST, //
+		GUILD_CHAT, //
+		PARTY_CHAT, //
+		PARTY_INVITE, //
+		SKYWARS_KILL, //
+		BEDWARS_KILL, //
+		MEGAWALLS_KILL, //
+		BLITZ_KILL, //
+		QUEST_COMPLETE, //
+		WIN //
+	}
 }

--- a/src/main/java/cc/hyperium/handlers/handlers/chat/KillTrackerChatHandler.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/chat/KillTrackerChatHandler.java
@@ -17,7 +17,7 @@ public class KillTrackerChatHandler extends HyperiumChatHandler{
      */
     @Override
     public boolean chatReceived(IChatComponent component, String text) {
-            //TODO
+        //TODO
         return false;
     }
 }

--- a/src/main/java/cc/hyperium/handlers/handlers/chat/PartyInviteChatHandler.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/chat/PartyInviteChatHandler.java
@@ -1,0 +1,25 @@
+package cc.hyperium.handlers.handlers.chat;
+
+import cc.hyperium.event.EventBus;
+import cc.hyperium.event.HypixelPartyInviteEvent;
+import net.minecraft.util.IChatComponent;
+
+import java.util.regex.Matcher;
+
+public class PartyInviteChatHandler extends HyperiumChatHandler {
+
+    @Override
+    public boolean chatReceived(IChatComponent component, String text) {
+        if (!text.toLowerCase().contains("their party!")) {
+            return false;
+        }
+
+        Matcher matcher = regexPatterns.get(ChatRegexType.PARTY_INVITE).matcher(text);
+
+        if (matcher.find()) {
+            EventBus.INSTANCE.post(new HypixelPartyInviteEvent(matcher.group("player")));
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/cc/hyperium/handlers/handlers/chat/PrivateMessageReader.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/chat/PrivateMessageReader.java
@@ -25,12 +25,12 @@ import java.util.regex.Matcher;
 public class PrivateMessageReader extends HyperiumChatHandler {
     @Override
     public boolean chatReceived(IChatComponent component, String text) {
-        Matcher fromMatcher = privateMessageFrom.matcher(text);
+        Matcher fromMatcher = regexPatterns.get(ChatRegexType.PRIVATE_MESSAGE_FROM).matcher(text);
         if (fromMatcher.matches()) {
             Hyperium.INSTANCE.getHandlers().getPrivateMessageHandler().inboundMessage(fromMatcher.group("player"), fromMatcher.group("message"));
         }
 
-        Matcher toMatcher = privateMessageTo.matcher(text);
+        Matcher toMatcher = regexPatterns.get(ChatRegexType.PRIVATE_MESSAGE_FROM).matcher(text);
         if (toMatcher.matches()) {
             Hyperium.INSTANCE.getHandlers().getPrivateMessageHandler().outboundMessage(toMatcher.group("player"), toMatcher.group("message"));
         }

--- a/src/main/java/cc/hyperium/handlers/handlers/chat/QuestTrackingChatHandler.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/chat/QuestTrackingChatHandler.java
@@ -199,7 +199,7 @@ public class QuestTrackingChatHandler extends HyperiumChatHandler{
     }
     @Override
     public boolean chatReceived(IChatComponent component, String text) {
-        Matcher matcher = completePattern.matcher(text);
+        Matcher matcher = regexPatterns.get(ChatRegexType.QUEST_COMPLETE).matcher(text);
         if(matcher.matches()){
             JsonObject record = new JsonObject();
             record.add("name", new JsonPrimitive(matcher.group("name")));

--- a/src/main/java/cc/hyperium/handlers/handlers/chat/RankedRatingChatHandler.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/chat/RankedRatingChatHandler.java
@@ -29,7 +29,7 @@ public class RankedRatingChatHandler extends HyperiumChatHandler {
 
     @Override
     public boolean chatReceived(IChatComponent component, String text) {
-        Matcher matcher = skywarsRankedRating.matcher(text);
+        Matcher matcher = regexPatterns.get(ChatRegexType.SKYWARS_RATING).matcher(text);
         if (matcher.matches()) {
             getHyperium().getHandlers().getValueHandler().setRankedRating(SafeNumberParsing.safeParseInt(matcher.group("rating"), getHyperium().getHandlers().getValueHandler().getRankedRating()));
             getHyperium().getHandlers().getValueHandler().setDeltaRankedRating(SafeNumberParsing.safeParseInt(matcher.group("change"), getHyperium().getHandlers().getValueHandler().getDeltaRankedRating()));

--- a/src/main/java/cc/hyperium/handlers/handlers/chat/WinTrackingChatHandler.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/chat/WinTrackingChatHandler.java
@@ -168,6 +168,11 @@
 
 package cc.hyperium.handlers.handlers.chat;
 
+import java.util.Arrays;
+import java.util.regex.Matcher;
+
+import cc.hyperium.event.EventBus;
+import cc.hyperium.event.HypixelWinEvent;
 import net.minecraft.util.IChatComponent;
 
 /*
@@ -175,8 +180,22 @@ import net.minecraft.util.IChatComponent;
  */
 public class WinTrackingChatHandler extends HyperiumChatHandler {
 
-    @Override
-    public boolean chatReceived(IChatComponent component, String text) {
-        return false; //TODO
-    }
+	@Override
+	public boolean chatReceived(IChatComponent component, String text) {
+		Matcher matcher = regexPatterns.get(ChatRegexType.WIN).matcher(text);
+		if (matcher.matches()) {
+		    String winnersString = matcher.group("winners");
+		    String[] winners = winnersString.split(", ");
+
+            for (int i = 0; i < winners.length; i++) {
+                String winner = winners[i];
+                // Means they have a rank prefix. We don't want that
+                if (winner.contains(" ")) {
+                    winners[i] = winner.split(" ")[1];
+                }
+            }
+            EventBus.INSTANCE.post(new HypixelWinEvent(Arrays.asList(winners)));
+		}
+		return false;
+	}
 }

--- a/src/main/java/cc/hyperium/handlers/handlers/chat/WinTrackingChatHandler.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/chat/WinTrackingChatHandler.java
@@ -169,10 +169,12 @@
 package cc.hyperium.handlers.handlers.chat;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.regex.Matcher;
 
 import cc.hyperium.event.EventBus;
 import cc.hyperium.event.HypixelWinEvent;
+import net.minecraft.client.Minecraft;
 import net.minecraft.util.IChatComponent;
 
 /*
@@ -195,6 +197,12 @@ public class WinTrackingChatHandler extends HyperiumChatHandler {
                 }
             }
             EventBus.INSTANCE.post(new HypixelWinEvent(Arrays.asList(winners)));
+		}
+
+		// Should actually change the regex tho
+		if (text.toLowerCase().contains(Minecraft.getMinecraft().thePlayer.getName().toLowerCase() + " winner!")) {
+			EventBus.INSTANCE
+					.post(new HypixelWinEvent(Collections.singletonList(Minecraft.getMinecraft().thePlayer.getName())));
 		}
 		return false;
 	}

--- a/src/main/kotlin/cc/hyperium/event/events.kt
+++ b/src/main/kotlin/cc/hyperium/event/events.kt
@@ -165,6 +165,11 @@ class HypixelFriendRequestEvent(val from: String)
 class HypixelPartyInviteEvent(val from: String)
 
 /**
+ * Invoked when player(s) win a game
+ */
+class HypixelWinEvent(val winners: List<String>)
+
+/**
  * Invoked when the selected item is about to be rendered
  */
 class RenderSelectedItemEvent(val scaledRes: ScaledResolution)
@@ -187,5 +192,3 @@ class EntityRenderEvent(val entityIn: Entity,
                         val model: ModelBiped, val p_78088_2_: Float,
                         val p_78088_3_: Float, val p_78088_4_: Float,
                         val p_78088_5_: Float, val p_78088_6_: Float, val scale: Float): CancellableEvent()
-
-class WinEvent()


### PR DESCRIPTION
- fixed chat handlers not being called ([see more](https://github.com/9Y0/Hyperium/blob/master/src/main/java/cc/hyperium/handlers/handlers/chat/GeneralChatHandler.java#L96))
- moved FriendRequestChatHandler and PartyInviteChatHandler to their own classes instead of in the GeneralChatHandler for cleanup
- chat regexes are now stored in  map keyed by a enum identical to the name in [this file](https://github.com/HyperiumClient/Hyperium-Repo/blob/master/files/chat_regex.json) (enums are uppercased)
- moved regex chat patterns that were hardcoded to the files repo ([see pull request to files repo](https://github.com/HyperiumClient/Hyperium-Repo/pull/2))