### PR TITLE
Fix infinite method call

### DIFF
--- a/src/main/java/cc/hyperium/utils/SafeNumberParsing.java
+++ b/src/main/java/cc/hyperium/utils/SafeNumberParsing.java
@@ -31,7 +31,7 @@ public final class SafeNumberParsing {
     }
 
     public static int safeParseInt(String input) {
-        return safeParseInt(input);
+        return safeParseInt(input, 0);
     }
 
 }


### PR DESCRIPTION
#safeParseInt(String) was in a state where it would call itself recursively rather than making a call to #safeParseInt(String, int) which I assume is the intended behaviour