### PR TITLE
Added blurred GUI backgrounds

### DIFF
--- a/src/main/java/cc/hyperium/gui/settings/items/GeneralSetting.java
+++ b/src/main/java/cc/hyperium/gui/settings/items/GeneralSetting.java
@@ -78,6 +78,8 @@ public class GeneralSetting extends SettingGui {
     public static boolean uploadScreenshotsByDefault = false;
     @ConfigOpt
     public static boolean hideScoreboardNumbers = true;
+    @ConfigOpt
+    public static boolean blurGuiBackgroundsEnabled = true;
 
     private SelectionItem<String> discordRP;
 
@@ -114,6 +116,8 @@ public class GeneralSetting extends SettingGui {
     private SelectionItem<String> uploadByDefault;
 
     private SelectionItem<String> scoreboardNumbers;
+
+    private SelectionItem<String> blurGuiBackgrounds;
 
     /** Set to true when a setting is changed, this will trigger a save when the gui is closed */
     private boolean settingsUpdated;
@@ -281,6 +285,14 @@ public class GeneralSetting extends SettingGui {
         }));
         scoreboardNumbers.addDefaultOnOff();
         scoreboardNumbers.setSelectedItem(hideScoreboardNumbers ? "ON" : "OFF");
+
+        this.settingItems.add(this.blurGuiBackgrounds = new SelectionItem<>(18, getX(), getDefaultItemY(18), this.width - getX() * 2, "BLUR GUI BACKGROUNDS", i -> {
+            ((SelectionItem) i).nextItem();
+            blurGuiBackgroundsEnabled = ((SelectionItem) i).getSelectedItem().equals("ON");
+            this.settingsUpdated = true;
+        }));
+        blurGuiBackgrounds.addDefaultOnOff();
+        blurGuiBackgrounds.setSelectedItem(blurGuiBackgroundsEnabled ? "ON" : "OFF");
     }
 
     /**

--- a/src/main/java/cc/hyperium/mixins/gui/MixinGuiContainer.java
+++ b/src/main/java/cc/hyperium/mixins/gui/MixinGuiContainer.java
@@ -1,0 +1,22 @@
+package cc.hyperium.mixins.gui;
+
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GuiContainer.class)
+public abstract class MixinGuiContainer extends GuiScreen {
+
+
+
+    /**
+     * @see MixinGuiScreen#onGuiClosed(CallbackInfo)
+     */
+    @Inject(method = "onGuiClosed", at = @At("HEAD"))
+    private void onGuiClosed(CallbackInfo ci) {
+        super.onGuiClosed();
+    }
+}

--- a/src/main/java/cc/hyperium/mixins/gui/MixinGuiEditSign.java
+++ b/src/main/java/cc/hyperium/mixins/gui/MixinGuiEditSign.java
@@ -1,14 +1,14 @@
 package cc.hyperium.mixins.gui;
 
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.gui.inventory.GuiEditSign;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(GuiContainer.class)
-public abstract class MixinGuiContainer extends GuiScreen {
+@Mixin(GuiEditSign.class)
+public abstract class MixinGuiEditSign extends GuiScreen {
 
     /**
      * @see MixinGuiScreen#onGuiClosed(CallbackInfo)
@@ -16,5 +16,13 @@ public abstract class MixinGuiContainer extends GuiScreen {
     @Inject(method = "onGuiClosed", at = @At("HEAD"))
     private void onGuiClosed(CallbackInfo ci) {
         super.onGuiClosed();
+    }
+
+    /**
+     * @see MixinGuiScreen#initGui(CallbackInfo)
+     */
+    @Inject(method = "initGui", at = @At("HEAD"))
+    private void initGui(CallbackInfo ci) {
+        super.initGui();
     }
 }

--- a/src/main/java/cc/hyperium/mixins/gui/MixinGuiScreen.java
+++ b/src/main/java/cc/hyperium/mixins/gui/MixinGuiScreen.java
@@ -20,6 +20,7 @@ package cc.hyperium.mixins.gui;
 import cc.hyperium.event.EventBus;
 import cc.hyperium.event.GuiClickEvent;
 import cc.hyperium.gui.settings.items.BackgroundSettings;
+import cc.hyperium.gui.settings.items.GeneralSetting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.EntityRenderer;
@@ -57,27 +58,29 @@ public abstract class MixinGuiScreen {
 
     @Inject(method = "initGui", at = @At("HEAD"))
     private void initGui(CallbackInfo ci) {
-        Minecraft.getMinecraft().addScheduledTask(() -> {
-            Method loadShaderMethod = null;
-            try {
-                loadShaderMethod = EntityRenderer.class.getDeclaredMethod("loadShader", ResourceLocation.class);
-            } catch (NoSuchMethodException e) {
+        if(GeneralSetting.blurGuiBackgroundsEnabled) {
+            Minecraft.getMinecraft().addScheduledTask(() -> {
+                Method loadShaderMethod = null;
                 try {
-                    loadShaderMethod = EntityRenderer.class.getDeclaredMethod("a", ResourceLocation.class);
-                } catch (NoSuchMethodException e1) {
-                    e1.printStackTrace();
+                    loadShaderMethod = EntityRenderer.class.getDeclaredMethod("loadShader", ResourceLocation.class);
+                } catch (NoSuchMethodException e) {
+                    try {
+                        loadShaderMethod = EntityRenderer.class.getDeclaredMethod("a", ResourceLocation.class);
+                    } catch (NoSuchMethodException e1) {
+                        e1.printStackTrace();
+                    }
                 }
-            }
 
-            if (loadShaderMethod != null) {
-                loadShaderMethod.setAccessible(true);
-                try {
-                    loadShaderMethod.invoke(Minecraft.getMinecraft().entityRenderer, new ResourceLocation("shaders/hyperium_blur.json"));
-                } catch (IllegalAccessException | InvocationTargetException e) {
-                    e.printStackTrace();
+                if (loadShaderMethod != null) {
+                    loadShaderMethod.setAccessible(true);
+                    try {
+                        loadShaderMethod.invoke(Minecraft.getMinecraft().entityRenderer, new ResourceLocation("shaders/hyperium_blur.json"));
+                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        e.printStackTrace();
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
     @Inject(method = "onGuiClosed", at = @At("HEAD"))

--- a/src/main/java/cc/hyperium/mixins/gui/MixinGuiScreen.java
+++ b/src/main/java/cc/hyperium/mixins/gui/MixinGuiScreen.java
@@ -20,11 +20,16 @@ package cc.hyperium.mixins.gui;
 import cc.hyperium.gui.settings.items.BackgroundSettings;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.util.ResourceLocation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 @Mixin(GuiScreen.class)
 public abstract class MixinGuiScreen {
@@ -38,4 +43,35 @@ public abstract class MixinGuiScreen {
         }
     }
 
+    @Inject(method = "initGui", at = @At("HEAD"))
+    private void initGui(CallbackInfo ci) {
+        Minecraft.getMinecraft().addScheduledTask(() -> {
+            Method loadShaderMethod = null;
+            try {
+                loadShaderMethod = EntityRenderer.class.getDeclaredMethod("loadShader", ResourceLocation.class);
+            } catch (NoSuchMethodException e) {
+                try {
+                    loadShaderMethod = EntityRenderer.class.getDeclaredMethod("a", ResourceLocation.class);
+                } catch (NoSuchMethodException e1) {
+                    e1.printStackTrace();
+                }
+            }
+
+            if (loadShaderMethod != null) {
+                loadShaderMethod.setAccessible(true);
+                try {
+                    loadShaderMethod.invoke(Minecraft.getMinecraft().entityRenderer, new ResourceLocation("shaders/hyperium_blur.json"));
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+
+    @Inject(method = "onGuiClosed", at = @At("HEAD"))
+    private void onGuiClosed(CallbackInfo ci) {
+        Minecraft.getMinecraft().addScheduledTask(() -> {
+            Minecraft.getMinecraft().entityRenderer.stopUseShader();
+        });
+    }
 }

--- a/src/main/java/cc/hyperium/mixins/gui/MixinGuiScreenBook.java
+++ b/src/main/java/cc/hyperium/mixins/gui/MixinGuiScreenBook.java
@@ -1,14 +1,14 @@
 package cc.hyperium.mixins.gui;
 
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.gui.GuiScreenBook;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(GuiContainer.class)
-public abstract class MixinGuiContainer extends GuiScreen {
+@Mixin(GuiScreenBook.class)
+public abstract class MixinGuiScreenBook extends GuiScreen {
 
     /**
      * @see MixinGuiScreen#onGuiClosed(CallbackInfo)
@@ -16,5 +16,13 @@ public abstract class MixinGuiContainer extends GuiScreen {
     @Inject(method = "onGuiClosed", at = @At("HEAD"))
     private void onGuiClosed(CallbackInfo ci) {
         super.onGuiClosed();
+    }
+    
+    /**
+     * @see MixinGuiScreen#initGui(CallbackInfo)
+     */
+    @Inject(method = "initGui", at = @At("HEAD"))
+    private void initGui(CallbackInfo ci) {
+        super.initGui();
     }
 }

--- a/src/main/resources/assets/minecraft/shaders/hyperium_blur.json
+++ b/src/main/resources/assets/minecraft/shaders/hyperium_blur.json
@@ -1,0 +1,34 @@
+{
+  "targets": [
+    "swap"
+  ],
+  "passes": [{
+    "name": "blur",
+    "intarget": "minecraft:main",
+    "outtarget": "swap",
+    "uniforms": [{
+      "name": "BlurDir",
+      "values": [1.0, 0.0]
+    },
+      {
+        "name": "Radius",
+        "values": [10.0]
+      }
+    ]
+  },
+    {
+      "name": "blur",
+      "intarget": "swap",
+      "outtarget": "minecraft:main",
+      "uniforms": [{
+        "name": "BlurDir",
+        "values": [0.0, 1.0]
+      },
+        {
+          "name": "Radius",
+          "values": [10.0]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/mixins.hyperium.json
+++ b/src/main/resources/mixins.hyperium.json
@@ -23,6 +23,8 @@
     "gui.MixinGuiButton",
     "gui.MixinGuiMainMenu",
     "gui.MixinGuiContainer",
+    "gui.MixinGuiEditSign",
+    "gui.MixinGuiScreenBook",
     "gui.MixinInventory",
     "gui.MixinGuiIngame",
     "gui.MixinGuiGameOver",

--- a/src/main/resources/mixins.hyperium.json
+++ b/src/main/resources/mixins.hyperium.json
@@ -22,6 +22,7 @@
     "gui.MixinGuiResourcePack",
     "gui.MixinGuiButton",
     "gui.MixinGuiMainMenu",
+    "gui.MixinGuiContainer",
     "gui.MixinInventory",
     "gui.MixinGuiIngame",
     "gui.MixinGuiGameOver",


### PR DESCRIPTION
Blurred GUI backgrounds are enabled by default. This should blur any screen that implements `GuiScreen` and calls `super.initGui()` and `super.onGuiClosed()`. Config option is in Hyperium Settings > General > Blur Gui Backgrounds