### PR TITLE
added fallback for disabling blurs when GUIs close

### DIFF
--- a/src/main/java/cc/hyperium/Hyperium.java
+++ b/src/main/java/cc/hyperium/Hyperium.java
@@ -25,6 +25,7 @@ import cc.hyperium.cosmetics.HyperiumCosmetics;
 import cc.hyperium.cosmetics.WingCosmetic;
 import cc.hyperium.event.*;
 import cc.hyperium.event.minigames.MinigameListener;
+import cc.hyperium.gui.BlurDisableFallback;
 import cc.hyperium.gui.ConfirmationPopup;
 import cc.hyperium.gui.NotificationCenter;
 import cc.hyperium.gui.settings.items.AnimationSettings;
@@ -149,6 +150,7 @@ public class Hyperium {
         //EventBus.INSTANCE.register(perspective = new PerspectiveModifierContainer());
         EventBus.INSTANCE.register(new WingCosmetic());
         EventBus.INSTANCE.register(confirmation = new ConfirmationPopup());
+        EventBus.INSTANCE.register(new BlurDisableFallback());
 
         // Register statistics tracking.
         EventBus.INSTANCE.register(statTrack);

--- a/src/main/java/cc/hyperium/gui/BlurDisableFallback.java
+++ b/src/main/java/cc/hyperium/gui/BlurDisableFallback.java
@@ -1,0 +1,37 @@
+package cc.hyperium.gui;
+
+import cc.hyperium.event.InvokeEvent;
+import cc.hyperium.event.TickEvent;
+import cc.hyperium.gui.settings.items.GeneralSetting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+
+/**
+ * Fallback for when GUIs don't disable blurring themselves
+ */
+public class BlurDisableFallback {
+
+    /**
+     * Last screen known to to be displayed to this object
+     */
+    private GuiScreen lastKnownScreen;
+
+    @InvokeEvent
+    private void onTick(TickEvent event) {
+        if(Minecraft.getMinecraft() != null &&
+                GeneralSetting.blurGuiBackgroundsEnabled &&
+                Minecraft.getMinecraft().entityRenderer != null &&
+                Minecraft.getMinecraft().entityRenderer.isShaderActive()) {
+
+            final GuiScreen currentScreen = Minecraft.getMinecraft().currentScreen;
+
+            if(lastKnownScreen != currentScreen) {
+                if(currentScreen == null) // Disable shaders if screen just closed
+                    Minecraft.getMinecraft().addScheduledTask(() ->
+                            Minecraft.getMinecraft().entityRenderer.stopUseShader());
+
+                lastKnownScreen = Minecraft.getMinecraft().currentScreen;
+            }
+        }
+    }
+}


### PR DESCRIPTION
If a GUI doesn't disable blurring itself, this now handles that. The downside to this is other shaders get disabled when GUIs close, but if a user wants that then perhaps they should disable GUI blurring. In the future this can be improved if necessary, this is just a quick fix.