### PR TITLE
Nametag flip direction fix

### DIFF
--- a/src/main/java/cc/hyperium/mixins/renderer/MixinRender.java
+++ b/src/main/java/cc/hyperium/mixins/renderer/MixinRender.java
@@ -1,6 +1,7 @@
 package cc.hyperium.mixins.renderer;
 
 import cc.hyperium.Hyperium;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
@@ -61,7 +62,11 @@ public abstract class MixinRender<T extends Entity> {
             GlStateManager.translate((float) x + 0.0F, (float) y + entityIn.height + 0.5F, (float) z);
             GL11.glNormal3f(0.0F, 1.0F, 0.0F);
             GlStateManager.rotate(-this.renderManager.playerViewY, 0.0F, 1.0F, 0.0F);
-            GlStateManager.rotate(this.renderManager.playerViewX, 1.0F, 0.0F, 0.0F);
+
+            int xMultiplier = 1; // Nametag x rotations should flip in front-facing 3rd person
+            if(Minecraft.getMinecraft() != null && Minecraft.getMinecraft().gameSettings != null &&Minecraft.getMinecraft().gameSettings.thirdPersonView == 2)
+                xMultiplier = -1;
+            GlStateManager.rotate(this.renderManager.playerViewX * xMultiplier, 1.0F, 0.0F, 0.0F);
             GlStateManager.scale(-f1, -f1, f1);
             GlStateManager.disableLighting();
             GlStateManager.depthMask(false);

--- a/src/main/java/cc/hyperium/mods/levelhead/renderer/LevelHeadRender.java
+++ b/src/main/java/cc/hyperium/mods/levelhead/renderer/LevelHeadRender.java
@@ -79,7 +79,11 @@ public class LevelHeadRender {
         GlStateManager.translate((float) x + 0.0F, (float) y + entityIn.height + 0.5F, (float) z);
         GL11.glNormal3f(0.0F, 1.0F, 0.0F);
         GlStateManager.rotate(-event.getRenderManager().playerViewY, 0.0F, 1.0F, 0.0F);
-        GlStateManager.rotate(event.getRenderManager().playerViewX, 1.0F, 0.0F, 0.0F);
+
+        int xMultiplier = 1; // Nametag x rotations should flip in front-facing 3rd person
+        if(Minecraft.getMinecraft() != null && Minecraft.getMinecraft().gameSettings != null &&Minecraft.getMinecraft().gameSettings.thirdPersonView == 2)
+            xMultiplier = -1;
+        GlStateManager.rotate(event.getRenderManager().playerViewX * xMultiplier, 1.0F, 0.0F, 0.0F);
         GlStateManager.scale(-f1, -f1, f1);
         GlStateManager.disableLighting();
         GlStateManager.depthMask(false);


### PR DESCRIPTION
fixed nametags rendering in the opposite direction when in front-facing third person
This fix also changes levelhead nametag rendering @Sk1er 