### PR TITLE
Improved Hypixel Detection

### DIFF
--- a/src/main/java/cc/hyperium/handlers/handlers/HypixelDetector.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/HypixelDetector.java
@@ -22,6 +22,7 @@ import cc.hyperium.event.*;
 import cc.hyperium.mods.sk1ercommon.Multithreading;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
+import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.util.ResourceLocation;
 
 import java.util.regex.Pattern;
@@ -49,25 +50,39 @@ public class HypixelDetector {
     public void serverJoinEvent(ServerJoinEvent event) {
         this.badlion = BADLION_PATTERN.matcher(event.getServer()).find();
         this.hypixel = HYPIXEL_PATTERN.matcher(event.getServer()).find();
-        if (hypixel) {
-            Multithreading.runAsync(() -> {
-                int tries = 0;
-                while (Minecraft.getMinecraft().thePlayer == null) {
-                    tries++;
-                    if (tries > 20 * 10) {
-                        return;
-                    }
-                    try {
-                        Thread.sleep(50L);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
+
+        Multithreading.runAsync(() -> {
+            // Wait a while until the player isn't null, signifying the joining process is complete
+            int tries = 0;
+            while (Minecraft.getMinecraft().thePlayer == null) {
+                tries++;
+                if (tries > 20 * 10) {
+                    return;
+                }
+                try {
+                    Thread.sleep(50L);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            if (hypixel) { // If player is online recognized Hypixel IP
+                EventBus.INSTANCE.post(new JoinHypixelEvent(JoinHypixelEvent.VerificationMethod.IP));
+
+            } else if (!badlion) { // Player ISNT on badlion, further Hypixel checks
+                if (Minecraft.getMinecraft() != null && Minecraft.getMinecraft().getCurrentServerData() != null) {
+                    final ServerData serverData = Minecraft.getMinecraft().getCurrentServerData();
+
+                    if(serverData != null) {
+                        // Check MOTD for Hypixel
+                        if (serverData.serverMOTD != null && serverData.serverMOTD.toLowerCase().contains("hypixel network")) {
+                            this.hypixel = true;
+                            EventBus.INSTANCE.post(new JoinHypixelEvent(JoinHypixelEvent.VerificationMethod.MOTD));
+                        }
                     }
                 }
-                EventBus.INSTANCE.post(new JoinHypixelEvent());
-            });
-
-
-        }
+            }
+        });
     }
 
     @InvokeEvent

--- a/src/main/java/cc/hyperium/handlers/handlers/HypixelDetector.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/HypixelDetector.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 public class HypixelDetector {
 
     private static final Pattern HYPIXEL_PATTERN =
-            Pattern.compile("^(?:(?:(?:\\w+\\.)?hypixel\\.net)|(?:209\\.222\\.115\\.\\d{1,3}))(?::\\d{1,5})?$", Pattern.CASE_INSENSITIVE);
+            Pattern.compile("^(?:(?:(?:.+\\.)?hypixel\\.net)|(?:209\\.222\\.115\\.\\d{1,3})|(?:99\\.198\\.123\\.[123]\\d?))(?::\\d{1,5})?$", Pattern.CASE_INSENSITIVE);
     private static final Pattern BADLION_PATTERN =
             Pattern.compile("^(?:(?:na|eu|sa)\\.badlion\\.net)(?::\\d{1,5})?$", Pattern.CASE_INSENSITIVE);
 

--- a/src/main/kotlin/cc/hyperium/event/events.kt
+++ b/src/main/kotlin/cc/hyperium/event/events.kt
@@ -207,8 +207,16 @@ class RenderSelectedItemEvent(val scaledRes: ScaledResolution)
 
 /**
  * Called when the player joins hypixel
+ * @param method method used to verify the player is online Hypixel
  */
-class JoinHypixelEvent
+class JoinHypixelEvent(val method: VerificationMethod) {
+    /**
+     * All the methods used by HypixelDetector to detect Hypixel
+     */
+    enum class VerificationMethod {
+        IP, MOTD
+    }
+}
 
 /**
  * Called when the game is shutting down, use this to save your configs


### PR DESCRIPTION
Hypixel detection has been improved to:
* Accept non-word characters in the subdomain.
* Accept `99.198.123.*` IPs.
* Accept other IPs otherwise ignored by MOTD verification.

Hyperium will attempt to check if the phrase "hypixel network" is in the server's MOTD when a user joins a server and the IP is not recognized as Hypixel or Badlion. This opens Hyperium up to phony Hypixel servers, creating wonky behaviour, but the pros outweigh the cons in my opinion.