### PR TITLE
Fixed search/filter component height issue

### DIFF
--- a/src/main/java/cc/hyperium/gui/hyperium/components/AbstractTab.java
+++ b/src/main/java/cc/hyperium/gui/hyperium/components/AbstractTab.java
@@ -65,7 +65,6 @@ public abstract class AbstractTab {
         if (scrollAnim.getValue() != scroll * 18 && scrollAnim.isFinished())
             scrollAnim = new SimpleAnimValue(1000L, scrollAnim.getValue(), scroll * 18);
         y += scrollAnim.getValue();
-
         /* Render each tab component */
         for (AbstractTabComponent comp : filter == null ? components : components.stream().filter(c -> c.filter(filter)).collect(Collectors.toList())) {
             comp.render(x, y, width, mx, my);

--- a/src/main/java/cc/hyperium/gui/hyperium/components/AbstractTabComponent.java
+++ b/src/main/java/cc/hyperium/gui/hyperium/components/AbstractTabComponent.java
@@ -12,6 +12,7 @@ import java.util.function.Consumer;
  * Created by Cubxity on 27/08/2018
  */
 public abstract class AbstractTabComponent {
+
     public boolean hover;
     protected List<String> tags = new ArrayList<>();
     protected AbstractTab tab;
@@ -30,7 +31,7 @@ public abstract class AbstractTabComponent {
     }
 
     public int getHeight() {
-        return 18;
+        return (tab.getFilter() != null && !filter(tab.getFilter())) ? 0 : 18;
     }
 
     public void render(int x, int y, int width, int mouseX, int mouseY) {

--- a/src/main/java/cc/hyperium/gui/playerrenderer/FakePlayerRendering.java
+++ b/src/main/java/cc/hyperium/gui/playerrenderer/FakePlayerRendering.java
@@ -14,6 +14,8 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldProvider;
 import net.minecraft.world.chunk.IChunkProvider;
 
+import java.awt.*;
+
 import static net.minecraft.client.Minecraft.getMinecraft;
 import static net.minecraft.client.renderer.GlStateManager.*;
 


### PR DESCRIPTION
Fixed an identified issue that was causing filtered components to appear invisible. Problem was that the height of the components was still being taken into consideration (Even if the component wasn't filtered)