### PR TITLE
Fixed settings title alignment

### DIFF
--- a/src/main/java/cc/hyperium/gui/hyperium/HyperiumMainGui.java
+++ b/src/main/java/cc/hyperium/gui/hyperium/HyperiumMainGui.java
@@ -166,7 +166,7 @@ public class HyperiumMainGui extends HyperiumGui {
         searchField.render(mouseX, mouseY);
         GlStateModifier.INSTANCE.reset();
 
-        title.drawCenteredTextScaled(I18n.format(currentTab.getTitle()), this.width / 2 - 4, yg + (yg / 2 - 8), 0xFFFFFF,1);
+        title.drawCenteredString(I18n.format(currentTab.getTitle()), this.width / 2, yg + (yg / 2 - 8), 0xFFFFFF);
 
         /* Render Body */
         currentTab.setFilter(searchField.getText().isEmpty() ? null : searchField.getText());

--- a/src/main/java/cc/hyperium/gui/hyperium/HyperiumMainGui.java
+++ b/src/main/java/cc/hyperium/gui/hyperium/HyperiumMainGui.java
@@ -40,6 +40,7 @@ import java.util.function.Supplier;
  * Created by Cubxity on 27/08/2018
  */
 public class HyperiumMainGui extends HyperiumGui {
+
     public static HyperiumMainGui INSTANCE = new HyperiumMainGui();
     private static int tabIndex = 0; // save tab position
     private int initialGuiScale;

--- a/src/main/java/cc/hyperium/utils/HyperiumFontRenderer.java
+++ b/src/main/java/cc/hyperium/utils/HyperiumFontRenderer.java
@@ -223,15 +223,8 @@ public class HyperiumFontRenderer {
         return drawString(text, x, y, color);
     }
 
-    /**
-     * Draw Centered String - Draw a centered string
-     * @param text - Given Text String
-     * @param x - Given X Position
-     * @param y - Given Y Position
-     * @param color - Given Color (HEX)
-     */
     public void drawCenteredString(String text, float x, float y, int color) {
-        drawString(text, x - (getStringWidth(text) / 2), y, color);
+        drawString(text, x - (int) getWidth(text) / 2, y, color);
     }
 
     /**


### PR DESCRIPTION
Originally I had made a temporary fix for the title alignment because it didn't align with the arrows. Now that the arrows are fixed, I can remove this temporary fix