### PR TITLE
Shiny Pots - Match potion color

### DIFF
--- a/src/main/java/cc/hyperium/config/Settings.java
+++ b/src/main/java/cc/hyperium/config/Settings.java
@@ -82,6 +82,10 @@ public class Settings {
     @ToggleSetting(name = "gui.settings.shinypotions", category = ANIMATIONS)
     public static boolean SHINY_POTS = false;
 
+    @ConfigOpt
+    @ToggleSetting(name ="gui.settings.shinypotions.matchcolor", category = ANIMATIONS)
+    public static boolean SHINY_POTS_MATCH_COLOR = false;
+
     @ConfigOpt(alt = "cc.hyperium.gui.settings.items.GeneralSetting;smartSoundsEnabled")
     @ToggleSetting(name = "gui.settings.smartsounds", category = IMPROVEMENTS)
     public static boolean SMART_SOUNDS = false;

--- a/src/main/java/cc/hyperium/mixinsimp/renderer/HyperiumRenderItem.java
+++ b/src/main/java/cc/hyperium/mixinsimp/renderer/HyperiumRenderItem.java
@@ -62,16 +62,9 @@ public class HyperiumRenderItem {
 
             if (cached != null) return cached;
             else {
-                // First we get the potion color.
-                int color = Items.potionitem.getColorFromItemStack(item, 0);
-
-                // The color is a RGB hex int, we have to convert it to the glint format first.
-                int red = (((color >> 16) & 0xFF) << 16) & 0x00FF0000;
-                int green = (((color >> 8) & 0xFF) << 8) & 0x0000FF00;
-                int blue = color & 0xFF;
-                int glint = 0xFF000000 | red | green | blue;
-                colorCache.put(potionId, glint);
-                return glint;
+                int color = Items.potionitem.getColorFromItemStack(item, 0) | 0xFF000000;
+                colorCache.put(potionId, color);
+                return color;
             }
         } else {
             return Colors.onepoint8glintcolorI;

--- a/src/main/java/cc/hyperium/mixinsimp/renderer/HyperiumRenderItem.java
+++ b/src/main/java/cc/hyperium/mixinsimp/renderer/HyperiumRenderItem.java
@@ -31,7 +31,6 @@ import org.lwjgl.opengl.GL11;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.HashMap;
 
 public class HyperiumRenderItem {
     private static final ResourceLocation RES_ITEM_GLINT = new ResourceLocation("textures/misc/enchanted_item_glint.png");

--- a/src/main/java/cc/hyperium/mixinsimp/renderer/HyperiumRenderItem.java
+++ b/src/main/java/cc/hyperium/mixinsimp/renderer/HyperiumRenderItem.java
@@ -56,7 +56,7 @@ public class HyperiumRenderItem {
     }
 
     private int getPotionColor(ItemStack item) {
-        if(Colors.enabled && Colors.matchPot) {
+        if(Settings.SHINY_POTS_MATCH_COLOR) {
             int potionId = item.getMetadata();
 
             Integer cached = colorCache.getIfPresent(potionId);

--- a/src/main/java/cc/hyperium/mods/glintcolorizer/Colors.java
+++ b/src/main/java/cc/hyperium/mods/glintcolorizer/Colors.java
@@ -26,6 +26,9 @@ public class Colors {
     @ConfigOpt
     @ToggleSetting(category = Category.GLINTCOLORIZER, mods = true, name = "Enabled")
     public static boolean enabled = false;
+    @ConfigOpt
+    @ToggleSetting(category = Category.GLINTCOLORIZER, mods = true, name = "Match potion")
+    public static boolean matchPot = false;
     private static float[] onepoint8glintcolorF = Color.RGBtoHSB(Colors.glintR, Colors.glintG, Colors.glintB, null);
     public static int onepoint8glintcolorI = Color.HSBtoRGB(Colors.onepoint8glintcolorF[0], Colors.onepoint8glintcolorF[1], Colors.onepoint8glintcolorF[2]);
 

--- a/src/main/java/cc/hyperium/mods/glintcolorizer/Colors.java
+++ b/src/main/java/cc/hyperium/mods/glintcolorizer/Colors.java
@@ -26,9 +26,6 @@ public class Colors {
     @ConfigOpt
     @ToggleSetting(category = Category.GLINTCOLORIZER, mods = true, name = "Enabled")
     public static boolean enabled = false;
-    @ConfigOpt
-    @ToggleSetting(category = Category.GLINTCOLORIZER, mods = true, name = "Match potion")
-    public static boolean matchPot = false;
     private static float[] onepoint8glintcolorF = Color.RGBtoHSB(Colors.glintR, Colors.glintG, Colors.glintB, null);
     public static int onepoint8glintcolorI = Color.HSBtoRGB(Colors.onepoint8glintcolorF[0], Colors.onepoint8glintcolorF[1], Colors.onepoint8glintcolorF[2]);
 

--- a/src/main/resources/assets/hyperium/lang/en_US.lang
+++ b/src/main/resources/assets/hyperium/lang/en_US.lang
@@ -127,6 +127,7 @@ gui.settings.voidflickerfix=Void Flicker Fix
 gui.settings.fpslimiter=FPS Limiter (in Limbo)
 gui.settings.fastchat=Fast Chat
 gui.settings.shinypotions=Shiny Potions
+gui.settings.shinypotions.matchcolor=Shiny Potions - Match Potion Color
 gui.settings.smartsounds=Smart Sounds
 gui.settings.numericping=Numeric Ping
 gui.settings.arrowcountwhenholdingbow=Arrow Count When Holding Bow


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after creating your pull request! -->
## Description  
The glint on the shiny potions matches the color of the potion itself.
Disabled by default, can be enabled through the "Shiny Pots - Match Potion Color" setting in the "Animations" category.

## Anything Else  
Needs the translation of the setting name for all locales other than English.

Additionally, it takes priority over Glint Colorizer, as you can see in this image:
![SP/GC example](https://i.imgur.com/1KfUUBJ.png)  
The matching color took priority over glint colorizer (which is active on the rendered item in the hand).

## Checklist  
<!-- You don't have to fill this out if you don't want to - just some things to keep in mind -->
- [x] All *new* Java and Kotlin files have the right copyright header  
- [x] I have tested my code by building it locally  
- [x] This is not a work-in-progress and is ready for merge  
- [x] I am submitting the PR under and understand the terms of the GNU Lesser General Public License v3.0  
