### PR TITLE
Fix renderitem not being compatible with OptiFine's custom item models

### DIFF
--- a/src/main/java/cc/hyperium/mixins/client/MixinMinecraft.java
+++ b/src/main/java/cc/hyperium/mixins/client/MixinMinecraft.java
@@ -126,7 +126,7 @@ public abstract class MixinMinecraft {
      *
      * @param ci {@see org.spongepowered.asm.mixin.injection.callback.CallbackInfo}
      */
-    @Inject(method = "dispatchKeypresses", at = @At(value = "INVOKE_ASSIGN", target = "Lorg/lwjgl/input/Keyboard;getEventKeyState()Z"))
+    @Inject(method = "dispatchKeypresses", at = @At(value = "INVOKE_ASSIGN", target = "Lorg/lwjgl/input/Keyboard;getEventKeyState()Z", remap = false))
     private void runTickKeyboard(CallbackInfo ci) {
         hyperiumMinecraft.runTickKeyboard();
     }
@@ -186,7 +186,7 @@ public abstract class MixinMinecraft {
         hyperiumMinecraft.displayFix(ci, fullscreen, displayWidth, displayHeight);
     }
 
-    @Inject(method = "toggleFullscreen", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/Display;setVSyncEnabled(Z)V", shift = At.Shift.AFTER))
+    @Inject(method = "toggleFullscreen", at = @At(value = "INVOKE", remap = false, target = "Lorg/lwjgl/opengl/Display;setVSyncEnabled(Z)V", shift = At.Shift.AFTER))
     private void fullScreenFix(CallbackInfo ci) throws LWJGLException {
         hyperiumMinecraft.fullScreenFix(fullscreen, displayWidth, displayHeight);
     }
@@ -229,7 +229,7 @@ public abstract class MixinMinecraft {
         hyperiumMinecraft.onStartGame();
     }
 
-    @Inject(method = "startGame", at = @At(value = "INVOKE", target = "java/util/List.add(Ljava/lang/Object;)Z", shift = At.Shift.BEFORE))
+    @Inject(method = "startGame", at = @At(value = "INVOKE", remap = false, target = "java/util/List.add(Ljava/lang/Object;)Z", shift = At.Shift.BEFORE))
     private void onLoadDefaultResourcePack(CallbackInfo ci) {
         hyperiumMinecraft.onLoadDefaultResourcePack();
     }
@@ -257,7 +257,7 @@ public abstract class MixinMinecraft {
         info.cancel();
     }
 
-    @Inject(method = "runTick", at = @At(value = "INVOKE", target = "Lorg/lwjgl/input/Mouse;getEventButton()I", ordinal = 0))
+    @Inject(method = "runTick", at = @At(value = "INVOKE", remap = false, target = "Lorg/lwjgl/input/Mouse;getEventButton()I", ordinal = 0))
     private void runTickMouseButton(CallbackInfo ci) {
         hyperiumMinecraft.runTickMouseButton();
     }

--- a/src/main/java/cc/hyperium/mixins/client/renderer/entity/MixinRenderItem.java
+++ b/src/main/java/cc/hyperium/mixins/client/renderer/entity/MixinRenderItem.java
@@ -17,6 +17,7 @@
 
 package cc.hyperium.mixins.client.renderer.entity;
 
+import cc.hyperium.config.Settings;
 import cc.hyperium.mixinsimp.client.renderer.entity.HyperiumRenderItem;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.resources.IResourceManagerReloadListener;
@@ -24,6 +25,9 @@ import net.minecraft.client.resources.model.IBakedModel;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
  * A Mixin to the RenderItem class to provide ShinyPots support, not to be confused with the
@@ -35,32 +39,41 @@ import org.spongepowered.asm.mixin.Overwrite;
 public abstract class MixinRenderItem implements IResourceManagerReloadListener {
 
     private HyperiumRenderItem hyperiumRenderItem = new HyperiumRenderItem((RenderItem) (Object) this);
+    private boolean wasJustRenderedAsPotion = false; // used to stop pots from rendering twice
+    private boolean isInv = false; // can't pass arguments between 2 @Injects so we have to do this
 
-    /**
-     * Overrides the normal method to use our custom one
-     *
-     * @param stack the item to render
-     * @param model the model of the item
-     * @reason Redirects the method to the "better" one
-     * @author boomboompower
-     */
-    @Overwrite
-    public void renderItem(ItemStack stack, IBakedModel model) {
-        hyperiumRenderItem.renderItem(stack, model, false);
+    @Inject(method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/resources/model/IBakedModel;)V", at = @At(value = "INVOKE", shift = At.Shift.BEFORE, target = "Lnet/minecraft/client/renderer/tileentity/TileEntityItemStackRenderer;renderByItem(Lnet/minecraft/item/ItemStack;)V"))
+    private void onRenderItem1(ItemStack stack, IBakedModel model, CallbackInfo ci) {
+        hyperiumRenderItem.callHeadScale(stack, isInv, Settings.HEAD_SCALE_FACTOR);
     }
 
-    /**
-     * Overrides the normal gui renderer to use our custom renderer instead
-     *
-     * @param stack the item to render
-     * @param x     the x location of the item
-     * @param y     the y location of the item
-     * @reason Changes the code to tell the renderer this is an inventory
-     * @author boomboompower
-     */
-    @Overwrite
-    public void renderItemIntoGUI(ItemStack stack, int x, int y) {
-        hyperiumRenderItem.renderItemIntoGUI(stack, x, y);
+    @Inject(method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/resources/model/IBakedModel;)V", at = @At(value = "INVOKE", shift = At.Shift.BEFORE, target = "Lnet/minecraft/client/renderer/entity/RenderItem;renderModel(Lnet/minecraft/client/resources/model/IBakedModel;Lnet/minecraft/item/ItemStack;)V"))
+    private void onRenderItem2(ItemStack stack, IBakedModel model, CallbackInfo ci) {
+        wasJustRenderedAsPotion = hyperiumRenderItem.renderShinyPot(stack, model, isInv);
+        hyperiumRenderItem.callHeadScale(stack, isInv, Settings.HEAD_SCALE_FACTOR);
+    }
+
+    @Inject(method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/resources/model/IBakedModel;)V", at = @At(value = "INVOKE", shift = At.Shift.BEFORE, target = "Lnet/minecraft/client/renderer/GlStateManager;popMatrix()V"))
+    private void onRenderItem3(ItemStack stack, IBakedModel model, CallbackInfo ci) {
+        hyperiumRenderItem.callHeadScale(stack, isInv, 1.0 / Settings.HEAD_SCALE_FACTOR);
+    }
+
+    @Inject(method = "renderEffect", at = @At("HEAD"), cancellable = true)
+    private void onRenderEffect(CallbackInfo ci) {
+        if (wasJustRenderedAsPotion) {
+            ci.cancel();
+        }
+        wasJustRenderedAsPotion = false; // cancel() != return so this still gets executed
+    }
+
+    @Inject(method = "renderItemIntoGUI", at = @At(value = "INVOKE", shift = At.Shift.BEFORE, target = "Lnet/minecraft/client/renderer/entity/RenderItem;renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/resources/model/IBakedModel;)V"))
+    private void onRenderItemIntoGUI(CallbackInfo ci) {
+        isInv = true;
+    }
+
+    @Inject(method = "renderItemIntoGUI", at = @At(value = "INVOKE", shift = At.Shift.AFTER, target = "Lnet/minecraft/client/renderer/entity/RenderItem;renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/resources/model/IBakedModel;)V"))
+    private void onRenderItemIntoGUIAfter(CallbackInfo ci) {
+        isInv = false;
     }
 }
 

--- a/src/main/java/cc/hyperium/mixins/world/MixinWorld.java
+++ b/src/main/java/cc/hyperium/mixins/world/MixinWorld.java
@@ -104,7 +104,7 @@ public abstract class MixinWorld {
         if (Settings.FULLBRIGHT && !Minecraft.getMinecraft().isIntegratedServerRunning()) cir.setReturnValue(15);
     }
 
-    @Inject(method = "joinEntityInSurroundings", at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", shift = At.Shift.AFTER))
+    @Inject(method = "joinEntityInSurroundings", at = @At(remap = false, value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", shift = At.Shift.AFTER))
     private void joinEntityInSurroundings(Entity entityIn, CallbackInfo ci) {
         EventBus.INSTANCE.post(new EntityJoinWorldEvent((World) (Object) this, entityIn));
     }

--- a/src/main/java/cc/hyperium/mixinsimp/client/renderer/entity/HyperiumRenderItem.java
+++ b/src/main/java/cc/hyperium/mixinsimp/client/renderer/entity/HyperiumRenderItem.java
@@ -69,7 +69,7 @@ public class HyperiumRenderItem {
     }
 
     /**
-     * Basically the same as the above method, but does not include the depth code
+     * Basically the same as renderEffect, but does not include the depth code and uses custom color
      *
      * @param model the model
      */


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after creating your pull request! -->
## Description  
Due to us overwriting some methods in RenderItem, OptiFine's custom item models didn't work. This fixes that.

## Checklist  
<!-- You don't have to fill this out if you don't want to - just some things to keep in mind -->
- [yes] All *new* Java and Kotlin files have the right copyright header  
- [yes] I have tested my code by building it locally  
- [yes] This is not a work-in-progress and is ready for merge  
- [yes] I am submitting the PR under and understand the terms of the GNU Lesser General Public License v3.0  
