### PR TITLE
New font renderer (~100,000 nanoseconds faster when rendering "Hyperium")

### DIFF
--- a/src/main/java/cc/hyperium/mods/levelhead/Levelhead.java
+++ b/src/main/java/cc/hyperium/mods/levelhead/Levelhead.java
@@ -48,6 +48,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.List;
@@ -84,7 +85,7 @@ public class Levelhead extends AbstractMod {
         LevelheadJsonHolder jsonHolder = new LevelheadJsonHolder();
 
         try {
-            jsonHolder = new LevelheadJsonHolder(FileUtils.readFileToString(new File(Hyperium.folder, "levelhead.json")));
+            jsonHolder = new LevelheadJsonHolder(FileUtils.readFileToString(new File(Hyperium.folder, "levelhead.json"), StandardCharsets.UTF_8));
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after creating your pull request! -->
## Description  
Optimize the custom font renderer by rendering blocks of text instead of each character individually. Saves about 100k nanoseconds, but that can quickly add up when rendering lots of text.

## Checklist  
<!-- You don't have to fill this out if you don't want to - just some things to keep in mind -->
- [yes] All *new* Java and Kotlin files have the right copyright header  
- [oui] I have tested my code by building it locally  
- [ja] This is not a work-in-progress and is ready for merge  
- [true] I am submitting the PR under and understand the terms of the GNU Lesser General Public License v3.0  
