### PR TITLE
Clarify JDK in mcgradle build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Hyperium is licensed under the GNU Lesser General Public License. You can view i
 	
 ### Building the Project with IntelliJ ###
 
+<!-- so nobody ever has to go through my pain again -violet -->
+**IMPORTANT NOTE: YOU MUST USE JDKu232 OR LOWER, OR IT WON'T BUILD!**
+
 #### Step 1 - Cloning
 - Click 'Clone or Download' and click the noteboard icon to copy to clipboard.
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after creating your pull request! -->
## Description  
It's important that Hyperium is built with JDK 8u232 or lower, or else it won't work. I didn't know this and struggled for hours.

## Context  
N/A

## Anything Else  
N/A

## Checklist  
<!-- You don't have to fill this out if you don't want to - just some things to keep in mind -->
- [x] All *new* Java and Kotlin files have the right copyright header  
- [x] I have tested my code by building it locally  
- [x] This is not a work-in-progress and is ready for merge  
- [x] I am submitting the PR under and understand the terms of the GNU Lesser General Public License v3.0  
