### PR TITLE
No more peonys

### DIFF
--- a/patches/net.minecraft.block.BlockDoublePlant.java.patch
+++ b/patches/net.minecraft.block.BlockDoublePlant.java.patch
@@ -1,0 +1,31 @@
+--- original/net/minecraft/block/BlockDoublePlant.java
++++ changed/net/minecraft/block/BlockDoublePlant.java
+@@ -1,7 +1,10 @@
+ package net.minecraft.block;
+ 
++import java.util.HashMap;
+ import java.util.List;
+ import java.util.Random;
++
++import cc.hyperium.config.Settings;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.properties.IProperty;
+ import net.minecraft.block.properties.PropertyEnum;
+@@ -229,6 +232,8 @@
+         return (meta & 8) > 0 ? this.getDefaultState().withProperty(HALF, BlockDoublePlant.EnumBlockHalf.UPPER) : this.getDefaultState().withProperty(HALF, BlockDoublePlant.EnumBlockHalf.LOWER).withProperty(VARIANT, BlockDoublePlant.EnumPlantType.byMetadata(meta & 7));
+     }
+ 
++    public static HashMap<BlockPos,EnumPlantType> variantMap = new HashMap<>();
++
+     /**
+      * Get the actual Block state of this Block at the given position. This applies properties not visible in the metadata,
+      * such as fence connections.
+@@ -239,7 +244,7 @@
+ 
+             if (iblockstate.getBlock() == this) {
+                 state = state.withProperty(VARIANT, iblockstate.getValue(VARIANT));
+-            }
++            } else if (Settings.DOUBLE_PLANT_FIX) return state.withProperty(VARIANT, variantMap.get(pos));
+         }
+ 
+         return state;

--- a/patches/net.minecraft.client.Minecraft.java.patch
+++ b/patches/net.minecraft.client.Minecraft.java.patch
@@ -32,7 +32,15 @@
  import com.google.common.collect.Iterables;
  import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
-@@ -91,6 +117,7 @@
+@@ -36,6 +62,7 @@
+ import java.util.concurrent.FutureTask;
+ import javax.imageio.ImageIO;
+ import net.minecraft.block.Block;
++import net.minecraft.block.BlockDoublePlant;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.client.audio.MusicTicker;
+ import net.minecraft.client.audio.SoundHandler;
+@@ -91,6 +118,7 @@
  import net.minecraft.client.resources.ResourcePackRepository;
  import net.minecraft.client.resources.SimpleReloadableResourceManager;
  import net.minecraft.client.resources.SkinManager;
@@ -40,7 +48,7 @@
  import net.minecraft.client.resources.data.AnimationMetadataSection;
  import net.minecraft.client.resources.data.AnimationMetadataSectionSerializer;
  import net.minecraft.client.resources.data.FontMetadataSection;
-@@ -159,6 +186,7 @@
+@@ -159,6 +187,7 @@
  import net.minecraft.util.Session;
  import net.minecraft.util.Timer;
  import net.minecraft.util.Util;
@@ -48,7 +56,7 @@
  import net.minecraft.world.EnumDifficulty;
  import net.minecraft.world.WorldProviderEnd;
  import net.minecraft.world.WorldProviderHell;
-@@ -226,7 +254,7 @@
+@@ -226,7 +255,7 @@
      private Entity renderViewEntity;
      public Entity pointedEntity;
      public EffectRenderer effectRenderer;
@@ -57,7 +65,7 @@
      private boolean isGamePaused;
      /** The font renderer used for displaying and measuring text */
      public FontRenderer fontRendererObj;
-@@ -286,7 +314,7 @@
+@@ -286,7 +315,7 @@
      /** Keeps track of how long the debug crash keycombo (F3+C) has been pressed for, in order to crash after 10 seconds. */
      private long debugCrashKeyPressTime = -1L;
      private IReloadableResourceManager mcResourceManager;
@@ -66,7 +74,7 @@
      private final List<IResourcePack> defaultResourcePacks = Lists.<IResourcePack>newArrayList();
      private final DefaultResourcePack mcDefaultResourcePack;
      private ResourcePackRepository mcResourcePackRepository;
-@@ -408,8 +436,25 @@
+@@ -408,8 +437,25 @@
       * Starts the game: initializes the canvas, the title, the settings, etcetera.
       */
      private void startGame() throws LWJGLException, IOException {
@@ -93,7 +101,7 @@
          this.startTimerHackThread();
  
          if (this.gameSettings.overrideHeight > 0 && this.gameSettings.overrideWidth > 0) {
-@@ -420,7 +465,13 @@
+@@ -420,7 +466,13 @@
          logger.info("LWJGL Version: " + Sys.getVersion());
          this.setWindowIcon();
          this.setInitialDisplayMode();
@@ -107,7 +115,7 @@
          OpenGlHelper.initializeTextures();
          this.framebufferMc = new Framebuffer(this.displayWidth, this.displayHeight, true);
          this.framebufferMc.setFramebufferColor(0.0F, 0.0F, 0.0F, 0.0F);
-@@ -524,6 +575,9 @@
+@@ -524,6 +576,9 @@
          }
  
          this.renderGlobal.makeEntityOutlineShader();
@@ -117,7 +125,7 @@
      }
  
      private void registerMetadataSerializers() {
-@@ -567,35 +621,37 @@
+@@ -567,35 +622,37 @@
      }
  
      private void setInitialDisplayMode() throws LWJGLException {
@@ -178,7 +186,7 @@
              }
          }
      }
-@@ -648,7 +704,12 @@
+@@ -648,7 +705,12 @@
       */
      public void displayCrashReport(CrashReport crashReportIn) {
          File file1 = new File(getMinecraft().mcDataDir, "crash-reports");
@@ -192,7 +200,7 @@
          Bootstrap.printToSYSOUT(crashReportIn.getCompleteReport());
  
          if (crashReportIn.getFile() != null) {
-@@ -755,51 +816,7 @@
+@@ -755,51 +817,7 @@
      }
  
      private void drawSplashScreen(TextureManager textureManagerInstance) throws LWJGLException {
@@ -245,7 +253,7 @@
      }
  
      /**
-@@ -844,14 +861,27 @@
+@@ -844,14 +862,27 @@
          }
  
          if (guiScreenIn == null && this.theWorld == null) {
@@ -277,7 +285,7 @@
          }
  
          this.currentScreen = (GuiScreen)guiScreenIn;
-@@ -867,6 +897,10 @@
+@@ -867,6 +898,10 @@
              this.mcSoundHandler.resumeSounds();
              this.setIngameFocus();
          }
@@ -288,7 +296,7 @@
      }
  
      /**
-@@ -916,6 +950,20 @@
+@@ -916,6 +951,20 @@
       * Called repeatedly from run()
       */
      private void runGameLoop() throws IOException {
@@ -309,7 +317,7 @@
          long i = System.nanoTime();
          this.mcProfiler.startSection("root");
  
-@@ -965,6 +1013,10 @@
+@@ -965,6 +1014,10 @@
  
          this.mcProfiler.endSection();
  
@@ -320,7 +328,7 @@
          if (!this.skipRenderWorld) {
              this.mcProfiler.endStartSection("gameRenderer");
              this.entityRenderer.updateCameraAndRender(this.timer.renderPartialTicks, i);
-@@ -1062,6 +1114,10 @@
+@@ -1062,6 +1115,10 @@
      }
  
      public int getLimitFramerate() {
@@ -331,7 +339,7 @@
          return this.theWorld == null && this.currentScreen != null ? 30 : this.gameSettings.limitFramerate;
      }
  
-@@ -1091,6 +1147,7 @@
+@@ -1091,6 +1148,7 @@
       * Update debugProfilerName in response to number keys in debug screen
       */
      private void updateDebugProfilerName(int keyCount) {
@@ -339,7 +347,7 @@
          List<Profiler.Result> list = this.mcProfiler.getProfilingData(this.debugProfilerName);
  
          if (list != null && !list.isEmpty()) {
-@@ -1222,6 +1279,7 @@
+@@ -1222,6 +1280,7 @@
       * Called when the window is closing. Sets 'running' to false which allows the game loop to exit cleanly.
       */
      public void shutdown() {
@@ -347,7 +355,7 @@
          this.running = false;
      }
  
-@@ -1314,6 +1372,8 @@
+@@ -1314,6 +1373,8 @@
                  }
              }
          }
@@ -356,7 +364,7 @@
      }
  
      /**
-@@ -1344,6 +1404,11 @@
+@@ -1344,6 +1405,11 @@
                      if (this.theWorld.getBlockState(blockpos).getBlock().getMaterial() != Material.air) {
                          int i = itemstack != null ? itemstack.stackSize : 0;
  
@@ -368,7 +376,7 @@
                          if (this.playerController.onPlayerRightClick(this.thePlayer, this.theWorld, itemstack, blockpos, this.objectMouseOver.sideHit, this.objectMouseOver.hitVec)) {
                              flag = false;
                              this.thePlayer.swingItem();
-@@ -1364,12 +1429,18 @@
+@@ -1364,12 +1430,18 @@
  
              if (flag) {
                  ItemStack itemstack1 = this.thePlayer.inventory.getCurrentItem();
@@ -387,7 +395,7 @@
      }
  
      /**
-@@ -1414,6 +1485,25 @@
+@@ -1414,6 +1486,25 @@
  
              Display.setFullscreen(this.fullscreen);
              Display.setVSyncEnabled(this.gameSettings.enableVsync);
@@ -413,7 +421,7 @@
              this.updateDisplay();
          } catch (Exception exception) {
              logger.error((String)"Couldn\'t toggle fullscreen", (Throwable)exception);
-@@ -1528,6 +1618,9 @@
+@@ -1528,6 +1619,9 @@
  
              while (Mouse.next()) {
                  int i = Mouse.getEventButton();
@@ -423,7 +431,7 @@
                  KeyBinding.setKeyBindState(i - 100, Mouse.getEventButtonState());
  
                  if (Mouse.getEventButtonState()) {
-@@ -1857,12 +1950,18 @@
+@@ -1857,12 +1951,18 @@
  
          this.mcProfiler.endSection();
          this.systemTime = getSystemTime();
@@ -442,7 +450,7 @@
          this.loadWorld((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.saveLoader.getSaveLoader(folderName, false);
-@@ -1912,7 +2011,15 @@
+@@ -1912,7 +2012,15 @@
          NetworkManager networkmanager = NetworkManager.provideLocalClient(socketaddress);
          networkmanager.setNetHandler(new NetHandlerLoginClient(networkmanager, this, (GuiScreen)null));
          networkmanager.sendPacket(new C00Handshake(47, socketaddress.toString(), 0, EnumConnectionState.LOGIN));
@@ -459,7 +467,7 @@
          this.myNetworkManager = networkmanager;
      }
  
-@@ -1920,6 +2027,9 @@
+@@ -1920,6 +2028,9 @@
       * unloads the current world first
       */
      public void loadWorld(WorldClient worldClientIn) {
@@ -469,7 +477,7 @@
          this.loadWorld(worldClientIn, "");
      }
  
-@@ -1986,7 +2096,9 @@
+@@ -1986,13 +2097,16 @@
              this.thePlayer = null;
          }
  
@@ -480,7 +488,14 @@
          this.systemTime = 0L;
      }
  
-@@ -2572,6 +2684,12 @@
+     public void setDimensionAndSpawnPlayer(int dimension) {
+         this.theWorld.setInitialSpawnLocation();
+         this.theWorld.removeAllEntities();
++        BlockDoublePlant.variantMap.clear(); //
+         int i = 0;
+         String s = null;
+ 
+@@ -2572,6 +2686,12 @@
  
          if (i != 0 && !Keyboard.isRepeatEvent()) {
              if (!(this.currentScreen instanceof GuiControls) || ((GuiControls)this.currentScreen).time <= getSystemTime() - 20L) {
@@ -493,7 +508,7 @@
                  if (Keyboard.getEventKeyState()) {
                      if (i == this.gameSettings.keyBindStreamStartStop.getKeyCode()) {
                          if (this.getTwitchStream().isBroadcasting()) {
-@@ -2610,7 +2728,8 @@
+@@ -2610,7 +2730,8 @@
                      } else if (i == this.gameSettings.keyBindFullscreen.getKeyCode()) {
                          this.toggleFullscreen();
                      } else if (i == this.gameSettings.keyBindScreenshot.getKeyCode()) {
@@ -503,7 +518,7 @@
                      }
                  } else if (i == this.gameSettings.keyBindStreamToggleMic.getKeyCode()) {
                      this.stream.muteMicrophone(false);
-@@ -2717,4 +2836,13 @@
+@@ -2717,4 +2838,13 @@
      public void setConnectedToRealms(boolean isConnected) {
          this.connectedToRealms = isConnected;
      }

--- a/patches/net.minecraft.client.multiplayer.PlayerControllerMP.java.patch
+++ b/patches/net.minecraft.client.multiplayer.PlayerControllerMP.java.patch
@@ -1,0 +1,36 @@
+--- original/net/minecraft/client/multiplayer/PlayerControllerMP.java
++++ changed/net/minecraft/client/multiplayer/PlayerControllerMP.java
+@@ -1,6 +1,8 @@
+ package net.minecraft.client.multiplayer;
+ 
++import cc.hyperium.config.Settings;
+ import net.minecraft.block.Block;
++import net.minecraft.block.BlockDoublePlant;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.client.Minecraft;
+@@ -10,6 +12,7 @@
+ import net.minecraft.entity.Entity;
+ import net.minecraft.entity.passive.EntityHorse;
+ import net.minecraft.entity.player.EntityPlayer;
++import net.minecraft.init.Blocks;
+ import net.minecraft.item.ItemBlock;
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.item.ItemSword;
+@@ -134,8 +137,16 @@
+                 return false;
+             } else {
+                 world.playAuxSFX(2001, pos, Block.getStateId(iblockstate));
++
+                 boolean flag = world.setBlockToAir(pos);
+ 
++                if (Settings.DOUBLE_PLANT_FIX) {
++                    if (iblockstate.getBlock().equals(Blocks.double_plant) && iblockstate.getValue(BlockDoublePlant.HALF).equals(BlockDoublePlant.EnumBlockHalf.LOWER)) {
++                        //world.setBlockState(pos.up(), iblockstate.withProperty(BlockDoublePlant.HALF, BlockDoublePlant.EnumBlockHalf.UPPER));
++                        BlockDoublePlant.variantMap.put(pos.up(),iblockstate.getValue(BlockDoublePlant.VARIANT));
++                    } // No need to fix lower block, since it would not do anything except lag.
++                }
++
+                 if (flag) {
+                     block1.onBlockDestroyedByPlayer(world, pos, iblockstate);
+                 }

--- a/patches/net.minecraft.client.multiplayer.PlayerControllerMP.java.patch
+++ b/patches/net.minecraft.client.multiplayer.PlayerControllerMP.java.patch
@@ -17,18 +17,15 @@
  import net.minecraft.item.ItemBlock;
  import net.minecraft.item.ItemStack;
  import net.minecraft.item.ItemSword;
-@@ -134,8 +137,16 @@
+@@ -134,8 +137,13 @@
                  return false;
              } else {
                  world.playAuxSFX(2001, pos, Block.getStateId(iblockstate));
 +
                  boolean flag = world.setBlockToAir(pos);
  
-+                if (Settings.DOUBLE_PLANT_FIX) {
-+                    if (iblockstate.getBlock().equals(Blocks.double_plant) && iblockstate.getValue(BlockDoublePlant.HALF).equals(BlockDoublePlant.EnumBlockHalf.LOWER)) {
-+                        //world.setBlockState(pos.up(), iblockstate.withProperty(BlockDoublePlant.HALF, BlockDoublePlant.EnumBlockHalf.UPPER));
-+                        BlockDoublePlant.variantMap.put(pos.up(),iblockstate.getValue(BlockDoublePlant.VARIANT));
-+                    } // No need to fix lower block, since it would not do anything except lag.
++                if (Settings.DOUBLE_PLANT_FIX && iblockstate.getBlock().equals(Blocks.double_plant) && iblockstate.getValue(BlockDoublePlant.HALF).equals(BlockDoublePlant.EnumBlockHalf.LOWER)) {
++                    BlockDoublePlant.variantMap.put(pos.up(),iblockstate.getValue(BlockDoublePlant.VARIANT));
 +                }
 +
                  if (flag) {

--- a/src/main/java/cc/hyperium/config/Settings.java
+++ b/src/main/java/cc/hyperium/config/Settings.java
@@ -549,6 +549,10 @@ public class Settings {
   @ToggleSetting(name = "gui.settings.disablearrowentities", category = PERFORMANCE)
   public static boolean DISABLE_ARROW_ENTITIES;
 
+  @ConfigOpt
+  @ToggleSetting(name = "gui.settings.doubleplantfix", category = QOL)
+  public static boolean DOUBLE_PLANT_FIX;
+
   public static void register() {
     Hyperium.CONFIG.register(INSTANCE);
   }

--- a/src/main/resources/assets/hyperium/lang/en_US.lang
+++ b/src/main/resources/assets/hyperium/lang/en_US.lang
@@ -222,6 +222,7 @@ gui.settings.fasttab=Fast Tab
 gui.settings.smoothchat=Smooth Chat
 gui.settings.chunkupdatelimit=Chunk Update Limit (EXPERIMENTAL)
 gui.settings.chunkupdatelimiting=Chunk Update Limiting (EXPERIMENTAL)
+gui.settings.doubleplantfix=Double plant fix
 
 #Keybind Categories
 keys.categories.hyperium=Hyperium


### PR DESCRIPTION
## Description  
Are you annoyed of seeing peonys when breaking the bottom of a double plant?
This makes the top block keep it's variant (by storing the variant to a hashmap)


## Checklist  
<!-- You don't have to fill this out if you don't want to - just some things to keep in mind -->
- [X] All *new* Java and Kotlin files have the right copyright header  
- [X] I have tested my code by building it locally  
- [X] This is not a work-in-progress and is ready for merge  
- [X] I am submitting the PR under and understand the terms of the GNU Lesser General Public License v3.0  
