### PR TITLE
Addon improvements and keybind stuff

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'club.ampthedev.mcgradle:MCGradle:2.0.8'
+        classpath 'club.ampthedev.mcgradle:MCGradle:2.0.10'
     }
 }
 

--- a/patches/net.minecraft.client.Minecraft.java.patch
+++ b/patches/net.minecraft.client.Minecraft.java.patch
@@ -443,7 +443,16 @@
                  KeyBinding.setKeyBindState(i - 100, Mouse.getEventButtonState());
  
                  if (Mouse.getEventButtonState()) {
-@@ -1857,12 +1956,18 @@
+@@ -1777,6 +1876,8 @@
+             }
+ 
+             this.sendClickBlockToController(this.currentScreen == null && this.gameSettings.keyBindAttack.isKeyDown() && this.inGameHasFocus);
++
++            Hyperium.INSTANCE.getHandlers().getKeybindHandler().onHold();
+         }
+ 
+         if (this.theWorld != null) {
+@@ -1857,12 +1958,18 @@
  
          this.mcProfiler.endSection();
          this.systemTime = getSystemTime();
@@ -462,7 +471,7 @@
          this.loadWorld((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.saveLoader.getSaveLoader(folderName, false);
-@@ -1912,7 +2017,15 @@
+@@ -1912,7 +2019,15 @@
          NetworkManager networkmanager = NetworkManager.provideLocalClient(socketaddress);
          networkmanager.setNetHandler(new NetHandlerLoginClient(networkmanager, this, (GuiScreen)null));
          networkmanager.sendPacket(new C00Handshake(47, socketaddress.toString(), 0, EnumConnectionState.LOGIN));
@@ -479,7 +488,7 @@
          this.myNetworkManager = networkmanager;
      }
  
-@@ -1920,6 +2033,9 @@
+@@ -1920,6 +2035,9 @@
       * unloads the current world first
       */
      public void loadWorld(WorldClient worldClientIn) {
@@ -489,7 +498,7 @@
          this.loadWorld(worldClientIn, "");
      }
  
-@@ -1986,13 +2102,16 @@
+@@ -1986,13 +2104,16 @@
              this.thePlayer = null;
          }
  
@@ -507,7 +516,7 @@
          int i = 0;
          String s = null;
  
-@@ -2572,6 +2691,12 @@
+@@ -2572,6 +2693,12 @@
  
          if (i != 0 && !Keyboard.isRepeatEvent()) {
              if (!(this.currentScreen instanceof GuiControls) || ((GuiControls)this.currentScreen).time <= getSystemTime() - 20L) {
@@ -520,7 +529,7 @@
                  if (Keyboard.getEventKeyState()) {
                      if (i == this.gameSettings.keyBindStreamStartStop.getKeyCode()) {
                          if (this.getTwitchStream().isBroadcasting()) {
-@@ -2610,7 +2735,8 @@
+@@ -2610,7 +2737,8 @@
                      } else if (i == this.gameSettings.keyBindFullscreen.getKeyCode()) {
                          this.toggleFullscreen();
                      } else if (i == this.gameSettings.keyBindScreenshot.getKeyCode()) {
@@ -530,7 +539,7 @@
                      }
                  } else if (i == this.gameSettings.keyBindStreamToggleMic.getKeyCode()) {
                      this.stream.muteMicrophone(false);
-@@ -2717,4 +2843,13 @@
+@@ -2717,4 +2845,13 @@
      public void setConnectedToRealms(boolean isConnected) {
          this.connectedToRealms = isConnected;
      }

--- a/src/main/java/cc/hyperium/handlers/handlers/keybinds/HyperiumKeybind.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/keybinds/HyperiumKeybind.java
@@ -45,6 +45,11 @@ public class HyperiumKeybind {
     pressed = false;
   }
 
+  /**
+   * Called every tick when a key is down, not just when it's pressed like onPress
+   */
+  public void onHold() {}
+
   public String getDescription() {
     return description;
   }

--- a/src/main/java/cc/hyperium/handlers/handlers/keybinds/HyperiumKeybind.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/keybinds/HyperiumKeybind.java
@@ -25,6 +25,7 @@ public class HyperiumKeybind {
   private String description, category;
   private int keyCode, defaultKeyCode;
   private boolean conflicted, pressed;
+  public boolean registered = false;
 
   public HyperiumKeybind(String description, int defaultKeyCode, KeyType category) {
     this(description, defaultKeyCode, category.keyCategory);

--- a/src/main/java/cc/hyperium/handlers/handlers/keybinds/HyperiumKeybindHandler.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/keybinds/HyperiumKeybindHandler.java
@@ -68,8 +68,12 @@ public class HyperiumKeybindHandler {
 
   public void registerKeybindings() {
     for (HyperiumKeybind bind : keybinds.values()) {
-      // Add the key to the `allKeys` map, so that it shows in GuiControl, and to the keyBindings list.
-      Minecraft.getMinecraft().gameSettings.keyBindings = ArrayUtils.add(Minecraft.getMinecraft().gameSettings.keyBindings, bind.toKeyBind());
+      // We should not register any keybinds more than just once
+      if (bind.registered) {
+        // Add the key to the `allKeys` map, so that it shows in GuiControl, and to the keyBindings list.
+        Minecraft.getMinecraft().gameSettings.keyBindings = ArrayUtils.add(Minecraft.getMinecraft().gameSettings.keyBindings, bind.toKeyBind());
+        bind.registered = true;
+      }
     }
   }
 

--- a/src/main/java/cc/hyperium/handlers/handlers/keybinds/HyperiumKeybindHandler.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/keybinds/HyperiumKeybindHandler.java
@@ -21,6 +21,8 @@ import cc.hyperium.Hyperium;
 import cc.hyperium.event.InvokeEvent;
 import cc.hyperium.event.client.GameShutDownEvent;
 import cc.hyperium.handlers.handlers.keybinds.keybinds.*;
+import cc.hyperium.internal.addons.AddonMinecraftBootstrap;
+import cc.hyperium.internal.addons.IAddon;
 import net.minecraft.client.Minecraft;
 
 import java.util.HashMap;
@@ -92,6 +94,12 @@ public class HyperiumKeybindHandler {
         }
         keyBind.setPressed(pressed);
       }
+    }
+  }
+
+  public void onHold() {
+    for (HyperiumKeybind keyBind : keybinds.values()) {
+      if (keyBind.isPressed()) keyBind.onHold();
     }
   }
 

--- a/src/main/java/cc/hyperium/handlers/handlers/keybinds/HyperiumKeybindHandler.java
+++ b/src/main/java/cc/hyperium/handlers/handlers/keybinds/HyperiumKeybindHandler.java
@@ -69,7 +69,7 @@ public class HyperiumKeybindHandler {
   public void registerKeybindings() {
     for (HyperiumKeybind bind : keybinds.values()) {
       // We should not register any keybinds more than just once
-      if (bind.registered) {
+      if (!bind.registered) {
         // Add the key to the `allKeys` map, so that it shows in GuiControl, and to the keyBindings list.
         Minecraft.getMinecraft().gameSettings.keyBindings = ArrayUtils.add(Minecraft.getMinecraft().gameSettings.keyBindings, bind.toKeyBind());
         bind.registered = true;

--- a/src/main/java/cc/hyperium/internal/ClassLoaderHelper.java
+++ b/src/main/java/cc/hyperium/internal/ClassLoaderHelper.java
@@ -1,0 +1,23 @@
+package cc.hyperium.internal;
+
+import cc.hyperium.Hyperium;
+import cc.hyperium.internal.addons.AddonBootstrap;
+import org.spongepowered.asm.launch.MixinBootstrap;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+
+public class ClassLoaderHelper {
+    public static void injectIntoClassLoader(boolean optifine) {
+        Hyperium.LOGGER.info("Loading Addons...");
+        Hyperium.LOGGER.info("Initialising Bootstraps...");
+        MixinBootstrap.init();
+        AddonBootstrap.INSTANCE.init();
+        Hyperium.LOGGER.info("Applying transformers...");
+        MixinEnvironment environment = MixinEnvironment.getDefaultEnvironment();
+
+        if (optifine || environment.getObfuscationContext() == null) {
+            environment.setObfuscationContext("notch");
+        }
+
+        environment.setSide(MixinEnvironment.Side.CLIENT);
+    }
+}

--- a/src/main/java/cc/hyperium/internal/ClassLoaderHelper.java
+++ b/src/main/java/cc/hyperium/internal/ClassLoaderHelper.java
@@ -1,3 +1,20 @@
+/*
+ *       Copyright (C) 2018-present Hyperium <https://hyperium.cc/>
+ *
+ *       This program is free software: you can redistribute it and/or modify
+ *       it under the terms of the GNU Lesser General Public License as published
+ *       by the Free Software Foundation, either version 3 of the License, or
+ *       (at your option) any later version.
+ *
+ *       This program is distributed in the hope that it will be useful,
+ *       but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *       GNU Lesser General Public License for more details.
+ *
+ *       You should have received a copy of the GNU Lesser General Public License
+ *       along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package cc.hyperium.internal;
 
 import cc.hyperium.Hyperium;
@@ -5,6 +22,9 @@ import cc.hyperium.internal.addons.AddonBootstrap;
 import org.spongepowered.asm.launch.MixinBootstrap;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 
+/**
+ * This class is used to load the addons from the same classloader as the game itself is in and not the classloader that the tweaker uses.
+ */
 public class ClassLoaderHelper {
     public static void injectIntoClassLoader(boolean optifine) {
         Hyperium.LOGGER.info("Loading Addons...");

--- a/src/main/kotlin/cc/hyperium/launch/HyperiumTweaker.kt
+++ b/src/main/kotlin/cc/hyperium/launch/HyperiumTweaker.kt
@@ -1,13 +1,10 @@
 package cc.hyperium.launch
 
 import cc.hyperium.Hyperium
-import cc.hyperium.internal.addons.AddonBootstrap.init
 import cc.hyperium.launch.patching.PatchManager
 import net.minecraft.launchwrapper.ITweaker
 import net.minecraft.launchwrapper.Launch
 import net.minecraft.launchwrapper.LaunchClassLoader
-import org.spongepowered.asm.launch.MixinBootstrap
-import org.spongepowered.asm.mixin.MixinEnvironment
 import java.io.File
 import java.io.IOException
 import java.net.MalformedURLException
@@ -49,19 +46,12 @@ class HyperiumTweaker : ITweaker {
         } catch (ignored: IOException) {
         }
 
-        Hyperium.LOGGER.info("Loading Addons...")
-        Hyperium.LOGGER.info("Initialising Bootstraps...")
-        MixinBootstrap.init()
-        init()
-        Hyperium.LOGGER.info("Applying transformers...")
-        val environment = MixinEnvironment.getDefaultEnvironment()
-
-        if (optifine) {
-            environment.obfuscationContext = "notch"
-        }
-
-        if (environment.obfuscationContext == null) {
-            environment.obfuscationContext = "notch"
+        try {
+            val clazz = Class.forName("cc.hyperium.ClassLoaderHelper", false, classLoader)
+            val m = clazz.getMethod("injectIntoClassLoader", Boolean::class.java)
+            m.invoke(null, optifine)
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
 
         try {
@@ -74,8 +64,6 @@ class HyperiumTweaker : ITweaker {
         } catch (e: MalformedURLException) {
             e.printStackTrace()
         }
-
-        environment.side = MixinEnvironment.Side.CLIENT
     }
 
     override fun getLaunchArguments(): Array<String?> {

--- a/src/main/kotlin/cc/hyperium/launch/HyperiumTweaker.kt
+++ b/src/main/kotlin/cc/hyperium/launch/HyperiumTweaker.kt
@@ -47,7 +47,7 @@ class HyperiumTweaker : ITweaker {
         }
 
         try {
-            val clazz = Class.forName("cc.hyperium.ClassLoaderHelper", false, classLoader)
+            val clazz = Class.forName("cc.hyperium.internal.ClassLoaderHelper", false, classLoader)
             val m = clazz.getMethod("injectIntoClassLoader", Boolean::class.java)
             m.invoke(null, optifine)
         } catch (e: Exception) {


### PR DESCRIPTION
## Description  
- This could make it possible to load addons (moves addon loading and processing to the same classloader as Minecraft itself. This was in the tweaker classloader before)
- Addons' keybinds can be registered without registering Hyperium binds twice.
- Add `onHold` method for Hyperium keybinds that get called every tick when the button is down.

## Context  
https://discordapp.com/channels/411619823445999637/576841425103093761/690580903625359401

## Anything Else  
A lot of this is from my fork's `mcgradle` branch.

## Checklist  
- [X] All *new* Java and Kotlin files have the right copyright header  
- [X] I have tested my code by building it locally  
- [X] This is not a work-in-progress and is ready for merge  
- [X] I am submitting the PR under and understand the terms of the GNU Lesser General Public License v3.0  
