### PR TITLE
Chat input stays on F11

### DIFF
--- a/patches/net.minecraft.client.gui.GuiChat.java.patch
+++ b/patches/net.minecraft.client.gui.GuiChat.java.patch
@@ -1,24 +1,33 @@
 --- original/net/minecraft/client/gui/GuiChat.java
 +++ changed/net/minecraft/client/gui/GuiChat.java
-@@ -1,5 +1,9 @@
+@@ -1,5 +1,10 @@
  package net.minecraft.client.gui;
  
 +import cc.hyperium.Hyperium;
++import cc.hyperium.config.Settings;
 +import cc.hyperium.handlers.handlers.HypixelDetector;
 +import cc.hyperium.mods.nickhider.NickHider;
 +import cc.hyperium.utils.ChatColor;
  import com.google.common.collect.Lists;
  import java.io.IOException;
  import java.util.List;
-@@ -55,6 +59,7 @@
-         this.inputField.setFocused(true);
-         this.inputField.setText(this.defaultInputFieldText);
-         this.inputField.setCanLoseFocus(false);
+@@ -49,11 +54,13 @@
+     public void initGui() {
+         Keyboard.enableRepeatEvents(true);
+         this.sentHistoryCursor = this.mc.ingameGUI.getChatGUI().getSentMessages().size();
++        String oldMsg = Settings.CHAT_KEEPER && this.inputField != null ? this.inputField.getText() : "";
+         this.inputField = new GuiTextField(0, this.fontRendererObj, 4, this.height - 12, this.width - 4, 12);
+-        this.inputField.setMaxStringLength(100);
 +        inputField.setMaxStringLength(HypixelDetector.getInstance().isHypixel() ? 256 : 100);
++        if (oldMsg.isEmpty()) this.inputField.setText(this.defaultInputFieldText);
++        else this.inputField.setText(oldMsg);
+         this.inputField.setEnableBackgroundDrawing(false);
+         this.inputField.setFocused(true);
+-        this.inputField.setText(this.defaultInputFieldText);
+         this.inputField.setCanLoseFocus(false);
      }
  
-     /**
-@@ -198,7 +203,7 @@
+@@ -198,7 +205,7 @@
              this.mc.ingameGUI.getChatGUI().printChatMessageWithOptionalDeletion(new ChatComponentText(stringbuilder.toString()), 1);
          }
  
@@ -27,7 +36,7 @@
      }
  
      private void sendAutocompleteRequest(String p_146405_1_, String p_146405_2_) {
-@@ -209,6 +214,7 @@
+@@ -209,6 +216,7 @@
                  blockpos = this.mc.objectMouseOver.getBlockPos();
              }
  
@@ -35,7 +44,7 @@
              this.mc.thePlayer.sendQueue.addToSendQueue(new C14PacketTabComplete(p_146405_1_, blockpos));
              this.waitingOnAutocomplete = true;
          }
-@@ -254,6 +260,9 @@
+@@ -254,6 +262,9 @@
      }
  
      public void onAutocompleteResponse(String[] p_146406_1_) {
@@ -45,7 +54,7 @@
          if (this.waitingOnAutocomplete) {
              this.playerNamesFound = false;
              this.foundPlayerNames.clear();
-@@ -267,9 +276,9 @@
+@@ -267,9 +278,9 @@
              String s1 = this.inputField.getText().substring(this.inputField.func_146197_a(-1, this.inputField.getCursorPosition(), false));
              String s2 = StringUtils.getCommonPrefix(p_146406_1_);
  
@@ -57,7 +66,7 @@
              } else if (this.foundPlayerNames.size() > 0) {
                  this.playerNamesFound = true;
                  this.autocompletePlayerNames();
-@@ -283,4 +292,8 @@
+@@ -283,4 +294,8 @@
      public boolean doesGuiPauseGame() {
          return false;
      }

--- a/patches/net.minecraft.client.gui.GuiChat.java.patch
+++ b/patches/net.minecraft.client.gui.GuiChat.java.patch
@@ -11,15 +11,25 @@
  import com.google.common.collect.Lists;
  import java.io.IOException;
  import java.util.List;
-@@ -49,11 +54,13 @@
+@@ -31,7 +36,7 @@
+     private int autocompleteIndex;
+     private List<String> foundPlayerNames = Lists.<String>newArrayList();
+     /** Chat entry field */
+-    protected GuiTextField inputField;
++    protected GuiTextField inputField = null;
+     /** is the text that appears when you press the chat key and the input box appears pre-filled */
+     private String defaultInputFieldText = "";
+ 
+@@ -49,11 +54,14 @@
      public void initGui() {
          Keyboard.enableRepeatEvents(true);
          this.sentHistoryCursor = this.mc.ingameGUI.getChatGUI().getSentMessages().size();
-+        String oldMsg = Settings.CHAT_KEEPER && this.inputField != null ? this.inputField.getText() : "";
++        boolean wasInitBefore = this.inputField != null;
++        String oldMsg = Settings.CHAT_KEEPER && wasInitBefore ? this.inputField.getText() : "";
          this.inputField = new GuiTextField(0, this.fontRendererObj, 4, this.height - 12, this.width - 4, 12);
 -        this.inputField.setMaxStringLength(100);
 +        inputField.setMaxStringLength(HypixelDetector.getInstance().isHypixel() ? 256 : 100);
-+        if (oldMsg.isEmpty()) this.inputField.setText(this.defaultInputFieldText);
++        if (!wasInitBefore) this.inputField.setText(this.defaultInputFieldText);
 +        else this.inputField.setText(oldMsg);
          this.inputField.setEnableBackgroundDrawing(false);
          this.inputField.setFocused(true);
@@ -27,7 +37,7 @@
          this.inputField.setCanLoseFocus(false);
      }
  
-@@ -198,7 +205,7 @@
+@@ -198,7 +206,7 @@
              this.mc.ingameGUI.getChatGUI().printChatMessageWithOptionalDeletion(new ChatComponentText(stringbuilder.toString()), 1);
          }
  
@@ -36,7 +46,7 @@
      }
  
      private void sendAutocompleteRequest(String p_146405_1_, String p_146405_2_) {
-@@ -209,6 +216,7 @@
+@@ -209,6 +217,7 @@
                  blockpos = this.mc.objectMouseOver.getBlockPos();
              }
  
@@ -44,7 +54,7 @@
              this.mc.thePlayer.sendQueue.addToSendQueue(new C14PacketTabComplete(p_146405_1_, blockpos));
              this.waitingOnAutocomplete = true;
          }
-@@ -254,6 +262,9 @@
+@@ -254,6 +263,9 @@
      }
  
      public void onAutocompleteResponse(String[] p_146406_1_) {
@@ -54,7 +64,7 @@
          if (this.waitingOnAutocomplete) {
              this.playerNamesFound = false;
              this.foundPlayerNames.clear();
-@@ -267,9 +278,9 @@
+@@ -267,9 +279,9 @@
              String s1 = this.inputField.getText().substring(this.inputField.func_146197_a(-1, this.inputField.getCursorPosition(), false));
              String s2 = StringUtils.getCommonPrefix(p_146406_1_);
  
@@ -66,7 +76,7 @@
              } else if (this.foundPlayerNames.size() > 0) {
                  this.playerNamesFound = true;
                  this.autocompletePlayerNames();
-@@ -283,4 +294,8 @@
+@@ -283,4 +295,8 @@
      public boolean doesGuiPauseGame() {
          return false;
      }

--- a/src/main/java/cc/hyperium/config/Settings.java
+++ b/src/main/java/cc/hyperium/config/Settings.java
@@ -553,6 +553,10 @@ public class Settings {
   @ToggleSetting(name = "gui.settings.doubleplantfix", category = QOL)
   public static boolean DOUBLE_PLANT_FIX;
 
+  @ConfigOpt
+  @ToggleSetting(name = "gui.settings.chatkeeper", category = QOL)
+  public static boolean CHAT_KEEPER;
+
   public static void register() {
     Hyperium.CONFIG.register(INSTANCE);
   }

--- a/src/main/resources/assets/hyperium/lang/en_US.lang
+++ b/src/main/resources/assets/hyperium/lang/en_US.lang
@@ -223,6 +223,7 @@ gui.settings.smoothchat=Smooth Chat
 gui.settings.chunkupdatelimit=Chunk Update Limit (EXPERIMENTAL)
 gui.settings.chunkupdatelimiting=Chunk Update Limiting (EXPERIMENTAL)
 gui.settings.doubleplantfix=Double plant fix
+gui.settings.chatkeeper=Keep chat messages on F11
 
 #Keybind Categories
 keys.categories.hyperium=Hyperium


### PR DESCRIPTION
MAMA, THAT LITTLE PESKY ~~THIEF TOOK MY LOLLIPOP~~ F11 KEY ATE MY MESSAGES!
## Description  
If not calling `GuiChat#initGui` for the first time, store chat input field's text before resetting the text field. Then set the text to the stored one.

## Context  
https://discordapp.com/channels/411619823445999637/429311217862180867/693160605284040844

## Anything Else  
I hope the F11 keys don't hate me from removing their only food source after LWJGL 2 bugs.

## Checklist  
<!-- You don't have to fill this out if you don't want to - just some things to keep in mind -->
- [X] All *new* Java and Kotlin files have the right copyright header  
- [X] I have tested my code by building it locally  
- [X] This is not a work-in-progress and is ready for merge  
- [X] I am submitting the PR under and understand the terms of the GNU Lesser General Public License v3.0  