### PR TITLE
Fixed the 1.7 Fishing Rod

### DIFF
--- a/patches/net.minecraft.client.renderer.ItemRenderer.java.patch
+++ b/patches/net.minecraft.client.renderer.ItemRenderer.java.patch
@@ -15,7 +15,7 @@
  import net.minecraft.util.BlockPos;
  import net.minecraft.util.EnumWorldBlockLayer;
  import net.minecraft.util.MathHelper;
-@@ -270,6 +272,24 @@
+@@ -270,6 +272,23 @@
       * Performs transformations prior to the rendering of a held item in first person.
       */
      private void transformFirstPersonItem(float equipProgress, float swingProgress) {
@@ -25,8 +25,7 @@
 +            GlStateManager.translate(0.0f, 0.05f, 0.04f);
 +        }
 +
-+        if (Settings.OLD_ROD && mc != null && mc.thePlayer != null && mc.thePlayer.getCurrentEquippedItem() != null && mc.thePlayer.getCurrentEquippedItem().getItem() !=
-+                null && Item.getIdFromItem(mc.thePlayer.getCurrentEquippedItem().getItem()) == 346) {
++        if (Settings.OLD_ROD && itemToRender != null && Item.getIdFromItem(itemToRender.getItem()) == 346) {
 +            GlStateManager.translate(0.08f, -0.027f, -0.33f);
 +            GlStateManager.scale(0.93f, 1.0f, 1.0f);
 +        }
@@ -40,7 +39,7 @@
          GlStateManager.translate(0.56F, -0.52F, -0.71999997F);
          GlStateManager.translate(0.0F, equipProgress * -0.6F, 0.0F);
          GlStateManager.rotate(45.0F, 0.0F, 1.0F, 0.0F);
-@@ -324,47 +344,63 @@
+@@ -324,47 +343,63 @@
       * Renders the active item in the player's hand when in first person mode. Args: partialTickTime
       */
      public void renderItemInFirstPerson(float partialTicks) {
@@ -138,7 +137,7 @@
          }
  
          GlStateManager.popMatrix();
-@@ -484,6 +520,8 @@
+@@ -484,6 +519,8 @@
       * @param partialTicks Partial ticks
       */
      private void renderFireInFirstPerson(float partialTicks) {
@@ -147,7 +146,7 @@
          Tessellator tessellator = Tessellator.getInstance();
          WorldRenderer worldrenderer = tessellator.getWorldRenderer();
          GlStateManager.color(1.0F, 1.0F, 1.0F, 0.9F);
-@@ -521,6 +559,8 @@
+@@ -521,6 +558,8 @@
          GlStateManager.disableBlend();
          GlStateManager.depthMask(true);
          GlStateManager.depthFunc(515);

--- a/patches/net.minecraft.client.renderer.entity.RenderFish.java.patch
+++ b/patches/net.minecraft.client.renderer.entity.RenderFish.java.patch
@@ -36,7 +36,7 @@
                  float f10 = (float)l / 16.0F;
                  worldrenderer.pos(x + d9 * (double)f10, y + d11 * (double)(f10 * f10 + f10) * 0.5D + 0.25D, z + d12 * (double)f10).color(0, 0, 0, 255).endVertex();
              }
--
+
              tessellator.draw();
              GlStateManager.enableLighting();
              GlStateManager.enableTexture2D();

--- a/patches/net.minecraft.client.renderer.entity.RenderFish.java.patch
+++ b/patches/net.minecraft.client.renderer.entity.RenderFish.java.patch
@@ -1,6 +1,13 @@
 --- original/net/minecraft/client/renderer/entity/RenderFish.java
 +++ changed/net/minecraft/client/renderer/entity/RenderFish.java
-@@ -11,6 +11,7 @@
+@@ -1,5 +1,6 @@
+ package net.minecraft.client.renderer.entity;
+ 
++import cc.hyperium.config.Settings;
+ import net.minecraft.client.Minecraft;
+ import net.minecraft.client.renderer.GlStateManager;
+ import net.minecraft.client.renderer.Tessellator;
+@@ -11,6 +12,7 @@
  import net.minecraft.util.Vec3;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
@@ -8,7 +15,7 @@
  
  @SideOnly(Side.CLIENT)
  public class RenderFish extends Render<EntityFishHook> {
-@@ -24,6 +25,7 @@
+@@ -24,6 +26,7 @@
       * Renders the desired {@code T} type Entity.
       */
      public void doRender(EntityFishHook entity, double x, double y, double z, float entityYaw, float partialTicks) {
@@ -16,3 +23,20 @@
          GlStateManager.pushMatrix();
          GlStateManager.translate((float)x, (float)y, (float)z);
          GlStateManager.enableRescaleNormal();
+@@ -54,7 +57,7 @@
+         if (entity.angler != null) {
+             float f7 = entity.angler.getSwingProgress(partialTicks);
+             float f8 = MathHelper.sin(MathHelper.sqrt_float(f7) * (float)Math.PI);
+-            Vec3 vec3 = new Vec3(-0.36D, 0.03D, 0.35D);
++            Vec3 vec3 = Settings.OLD_ROD ? new Vec3(-0.5D, 0.03D, 0.8D) : new Vec3(-0.36D, 0.03D, 0.35D);
+             vec3 = vec3.rotatePitch(-(entity.angler.prevRotationPitch + (entity.angler.rotationPitch - entity.angler.prevRotationPitch) * partialTicks) * (float)Math.PI / 180.0F);
+             vec3 = vec3.rotateYaw(-(entity.angler.prevRotationYaw + (entity.angler.rotationYaw - entity.angler.prevRotationYaw) * partialTicks) * (float)Math.PI / 180.0F);
+             vec3 = vec3.rotateYaw(f8 * 0.5F);
+@@ -91,7 +94,6 @@
+                 float f10 = (float)l / 16.0F;
+                 worldrenderer.pos(x + d9 * (double)f10, y + d11 * (double)(f10 * f10 + f10) * 0.5D + 0.25D, z + d12 * (double)f10).color(0, 0, 0, 255).endVertex();
+             }
+-
+             tessellator.draw();
+             GlStateManager.enableLighting();
+             GlStateManager.enableTexture2D();


### PR DESCRIPTION
Fixed 3 issues with the 1.7 fishing rod in Hyperium
1. When switching from another item to a fishing rod, the other item used to be scaled as it was dequipped, now it isn't.
2. When switching from a fishing rod to another item, the fishing rod used to be shown at the normal scale as it was dequipped, now it isn't.
3. The fishing line used to be in the 1.8 position even with 1.7 rod enabled, now it isn't.

These still occur with Orange's and Spiderfrog's Old Animations so ours is now the best :P