### PR TITLE
Fix MC-77759 - keys 

### DIFF
--- a/patches/net.minecraft.client.Minecraft.java.patch
+++ b/patches/net.minecraft.client.Minecraft.java.patch
@@ -539,7 +539,12 @@
          int i = 0;
          String s = null;
  
-@@ -2572,6 +2699,12 @@
+@@ -2568,10 +2695,16 @@
+     }
+ 
+     public void dispatchKeypresses() {
+-        int i = Keyboard.getEventKey() == 0 ? Keyboard.getEventCharacter() : Keyboard.getEventKey();
++        int i = Keyboard.getEventKey() == 0 ? Keyboard.getEventCharacter() + 256 : Keyboard.getEventKey();
  
          if (i != 0 && !Keyboard.isRepeatEvent()) {
              if (!(this.currentScreen instanceof GuiControls) || ((GuiControls)this.currentScreen).time <= getSystemTime() - 20L) {

--- a/patches/net.minecraft.client.Minecraft.java.patch
+++ b/patches/net.minecraft.client.Minecraft.java.patch
@@ -539,7 +539,7 @@
          int i = 0;
          String s = null;
  
-@@ -2568,10 +2695,16 @@
+@@ -2568,10 +2695,15 @@
      }
  
      public void dispatchKeypresses() {
@@ -548,16 +548,15 @@
  
          if (i != 0 && !Keyboard.isRepeatEvent()) {
              if (!(this.currentScreen instanceof GuiControls) || ((GuiControls)this.currentScreen).time <= getSystemTime() - 20L) {
-+                int key = Keyboard.getEventKey();
 +                boolean repeat = Keyboard.isRepeatEvent();
 +                boolean press = Keyboard.getEventKeyState();
-+                Hyperium.INSTANCE.getHandlers().getKeybindHandler().handleKey(key, press);
-+                EventBus.INSTANCE.post(press ? new KeyPressEvent(key, repeat) : new KeyReleaseEvent(key, repeat));
++                Hyperium.INSTANCE.getHandlers().getKeybindHandler().handleKey(i, press);
++                EventBus.INSTANCE.post(press ? new KeyPressEvent(i, repeat) : new KeyReleaseEvent(i, repeat));
 +
                  if (Keyboard.getEventKeyState()) {
                      if (i == this.gameSettings.keyBindStreamStartStop.getKeyCode()) {
                          if (this.getTwitchStream().isBroadcasting()) {
-@@ -2610,7 +2743,8 @@
+@@ -2610,7 +2742,8 @@
                      } else if (i == this.gameSettings.keyBindFullscreen.getKeyCode()) {
                          this.toggleFullscreen();
                      } else if (i == this.gameSettings.keyBindScreenshot.getKeyCode()) {
@@ -567,7 +566,7 @@
                      }
                  } else if (i == this.gameSettings.keyBindStreamToggleMic.getKeyCode()) {
                      this.stream.muteMicrophone(false);
-@@ -2717,4 +2851,13 @@
+@@ -2717,4 +2850,13 @@
      public void setConnectedToRealms(boolean isConnected) {
          this.connectedToRealms = isConnected;
      }


### PR DESCRIPTION
Fix <|\> key (below A, between left shift and Z key) taking screenshots on some non-US keyboard layouts including Nordic, German and Italian.

https://bugs.mojang.com/browse/MC-77759

## Checklist  
<!-- You don't have to fill this out if you don't want to - just some things to keep in mind -->
- [x] All *new* Java and Kotlin files have the right copyright header  
- [X] I have tested my code by building it locally  
- [X] This is not a work-in-progress and is ready for merge  
- [X] I am submitting the PR under and understand the terms of the GNU Lesser General Public License v3.0  


this was like the smallest fix ever, but idc
