### PR TITLE
Exclude Kotlin metadata files that break Kotlin use in Addons

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,10 @@ jar {
         }
     }
     exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
+    // Exclude kotlin metadata files that break the ability to use Kotlin for Addon-Workspace addons. See https://youtrack.jetbrains.com/issue/KT-25709#focus=Comments-27-3752033.0-0
+    exclude '**/*.kotlin_metadata'
+    exclude '**/*.kotlin_module'
+    exclude '**/*.kotlin_builtins'
 }
 
 jar {


### PR DESCRIPTION
Exclude kotlin metadata files that break the ability to use Kotlin for Addon-Workspace addons. 

<!-- Anything that looks like this is a comment and can't be seen after creating your pull request! -->
## Description  

After raising this issue on discord, it was suggested I make a PR: https://discord.com/channels/411619823445999637/576841425103093761/742629286149750854

Here's what I said in discord:
I am successfully using the nice Hyperium Addon workspace to create  the sample add-on. I’d like to code in Kotlin (I’m teaching my son to learn Kotlin), so I updated the build.gradle to support kotlin. I then created any IAddon successfully and it compiles, but it seems there’s a bug in IntelliJ related to Kotlin and fat jars that makes it so the IDE shows any import from the Hyperium jar as invalid, and code completion and navigation to classes fails on anything from that jar.

I tried a pretty straightforward workaround found in the kotlin bug ticket ( basically, add a few excludes for some Kotlin metadata files  in the HyperiumClient build.gradle) and that seems to work to make the Kotlin Addon show properly in IntelliJ. Here’s the link to the workaround and underlying issue: https://youtrack.jetbrains.com/issue/KT-25709#focus=Comments-27-3752033.0-0
<!-- A description of your change.  Keep it short. -->  

## Context  
<!-- If this fixes an issue, link it here. -->  

## Anything Else  
<!-- Put anything else relevant to this pull request here. -->

## Checklist  
<!-- You don't have to fill this out if you don't want to - just some things to keep in mind -->
- [] All *new* Java and Kotlin files have the right copyright header  
- [] I have tested my code by building it locally  
- [] This is not a work-in-progress and is ready for merge  
- [] I am submitting the PR under and understand the terms of the GNU Lesser General Public License v3.0  
